### PR TITLE
Update MSFT_xADUser.psm1

### DIFF
--- a/DSCResources/MSFT_xADUser/MSFT_xADUser.psm1
+++ b/DSCResources/MSFT_xADUser/MSFT_xADUser.psm1
@@ -137,6 +137,7 @@ function ValidateProperties
             if( $Apply )
             {
                 Remove-ADUser -Identity $UserName -Credential $DomainAdministratorCredential -Confirm:$false
+                Write-Verbose -Message "Removed $UserName account in domain $DomainName."
                 return
             }
             else
@@ -201,10 +202,11 @@ function ValidateProperties
         {
             if( $Ensure -ne "Absent" )
             {
-                $params = @{ Name = $UserName; Enabled = $true; Credential = $DomainAdministratorCredential }
+                $params = @{ Name = $UserName; Credential = $DomainAdministratorCredential }
                 if( $Password )
                 {
                     $params.Add( "AccountPassword", $Password.Password )
+                    $params.Add( "Enabled", $true )
                 }
                 New-AdUser @params
                 Write-Verbose -Message "User $UserName account in domain $DomainName has been created"


### PR DESCRIPTION
Line 140: Added a missing Write-Verbose when removing users when Ensure = ‘Absent’.
Line 209: Moved Enabled to the If ($Password) block, because new AD users cannot be enabled without a password.