### PR TITLE
Updated xADDomainTrust and xADRecycleBin test

### DIFF
--- a/DSCResources/MSFT_xADDomainTrust/MSFT_xADDomainTrust.psm1
+++ b/DSCResources/MSFT_xADDomainTrust/MSFT_xADDomainTrust.psm1
@@ -66,25 +66,15 @@ function Get-TargetResource
     {
         switch ($TrustType)
         {
-            'External'
-            {
-                # Create the target domain object
-                $trgDirectoryContext = New-Object System.DirectoryServices.ActiveDirectory.DirectoryContext('domain',$TargetDomainName, $TargetDomainAdministratorCredential.UserName, $TargetDomainAdministratorCredential.GetNetworkCredential().Password)
-                $trgDomain = [System.DirectoryServices.ActiveDirectory.Domain]::GetDomain($trgDirectoryContext)
-                # Create the source domain object
-                $srcDirectoryContext = New-Object System.DirectoryServices.ActiveDirectory.DirectoryContext('domain',$SourceDomainName)
-                $srcDomain = [System.DirectoryServices.ActiveDirectory.Domain]::GetDomain($srcDirectoryContext)
-            }
-            'Forest'
-            {
-                # Create the target forest object
-                $trgDirectoryContext = New-Object System.DirectoryServices.ActiveDirectory.DirectoryContext('forest',$TargetDomainName, $TargetDomainAdministratorCredential.UserName, $TargetDomainAdministratorCredential.GetNetworkCredential().Password)
-                $trgDomain = [System.DirectoryServices.ActiveDirectory.Forest]::GetForest($trgDirectoryContext)
-                # Create the source forest object
-                $srcDirectoryContext = New-Object System.DirectoryServices.ActiveDirectory.DirectoryContext('forest',$SourceDomainName)
-                $srcDomain = [System.DirectoryServices.ActiveDirectory.Forest]::GetForest($srcDirectoryContext)
-            }
+            'External' {$DomainOrForest = 'Domain'}
+            'Forest' {$DomainOrForest = 'Forest'}
         }
+        # Create the target object
+        $trgDirectoryContext = New-Object System.DirectoryServices.ActiveDirectory.DirectoryContext($DomainOrForest,$TargetDomainName, $TargetDomainAdministratorCredential.UserName, $TargetDomainAdministratorCredential.GetNetworkCredential().Password)
+        $trgDomain = ([type]"System.DirectoryServices.ActiveDirectory.$DomainOrForest")::"Get$DomainOrForest"($trgDirectoryContext)
+        # Create the source object
+        $srcDirectoryContext = New-Object System.DirectoryServices.ActiveDirectory.DirectoryContext($DomainOrForest,$SourceDomainName)
+        $srcDomain = ([type]"System.DirectoryServices.ActiveDirectory.$DomainOrForest")::"Get$DomainOrForest"($srcDirectoryContext)
 
         # Find trust betwen source & destination.
         $trust = $srcDomain.GetTrustRelationship($trgDomain)
@@ -228,25 +218,15 @@ function Validate-ResourceProperties
 
         switch ($TrustType)
         {
-            'External'
-            {
-                # Create the target domain object
-                $trgDirectoryContext = New-Object System.DirectoryServices.ActiveDirectory.DirectoryContext('domain',$TargetDomainName, $TargetDomainAdministratorCredential.UserName, $TargetDomainAdministratorCredential.GetNetworkCredential().Password)
-                $trgDomain = [System.DirectoryServices.ActiveDirectory.Domain]::GetDomain($trgDirectoryContext)
-                # Create the source domain object
-                $srcDirectoryContext = New-Object System.DirectoryServices.ActiveDirectory.DirectoryContext('domain',$SourceDomainName)
-                $srcDomain = [System.DirectoryServices.ActiveDirectory.Domain]::GetDomain($srcDirectoryContext)
-            }
-            'Forest'
-            {
-                # Create the target forest object
-                $trgDirectoryContext = New-Object System.DirectoryServices.ActiveDirectory.DirectoryContext('forest',$TargetDomainName, $TargetDomainAdministratorCredential.UserName, $TargetDomainAdministratorCredential.GetNetworkCredential().Password)
-                $trgDomain = [System.DirectoryServices.ActiveDirectory.Forest]::GetForest($trgDirectoryContext)
-                # Create the source forest object
-                $srcDirectoryContext = New-Object System.DirectoryServices.ActiveDirectory.DirectoryContext('forest',$SourceDomainName)
-                $srcDomain = [System.DirectoryServices.ActiveDirectory.Forest]::GetForest($srcDirectoryContext)
-            }
+            'External' {$DomainOrForest = 'Domain'}
+            'Forest' {$DomainOrForest = 'Forest'}
         }
+        # Create the target object
+        $trgDirectoryContext = New-Object System.DirectoryServices.ActiveDirectory.DirectoryContext($DomainOrForest,$TargetDomainName, $TargetDomainAdministratorCredential.UserName, $TargetDomainAdministratorCredential.GetNetworkCredential().Password)
+        $trgDomain = ([type]"System.DirectoryServices.ActiveDirectory.$DomainOrForest")::"Get$DomainOrForest"($trgDirectoryContext)
+        # Create the source object
+        $srcDirectoryContext = New-Object System.DirectoryServices.ActiveDirectory.DirectoryContext($DomainOrForest,$SourceDomainName)
+        $srcDomain = ([type]"System.DirectoryServices.ActiveDirectory.$DomainOrForest")::"Get$DomainOrForest"($srcDirectoryContext)
 
         # Find trust
         try

--- a/DSCResources/MSFT_xADDomainTrust/MSFT_xADDomainTrust.psm1
+++ b/DSCResources/MSFT_xADDomainTrust/MSFT_xADDomainTrust.psm1
@@ -35,7 +35,7 @@ function Get-TargetResource
         [PSCredential]$TargetDomainAdministratorCredential,
 
         [parameter(Mandatory)]
-        [ValidateSet("External")]
+        [ValidateSet("External","Forest")]
         [String]$TrustType,
 
         [parameter(Mandatory)]
@@ -64,13 +64,27 @@ function Get-TargetResource
 
     try
     {
-        # Create the target domain object
-        $trgDirectoryContext = New-Object System.DirectoryServices.ActiveDirectory.DirectoryContext('domain',$TargetDomainName, $TargetDomainAdministratorCredential.UserName, $TargetDomainAdministratorCredential.GetNetworkCredential().Password)
-        $trgDomain = [System.DirectoryServices.ActiveDirectory.Domain]::GetDomain($trgDirectoryContext)
-
-        # Create the source domain object
-        $srcDirectoryContext = New-Object System.DirectoryServices.ActiveDirectory.DirectoryContext('domain',$SourceDomainName)
-        $srcDomain = [System.DirectoryServices.ActiveDirectory.Domain]::GetDomain($srcDirectoryContext)
+        switch ($TrustType)
+        {
+            'External'
+            {
+                # Create the target domain object
+                $trgDirectoryContext = New-Object System.DirectoryServices.ActiveDirectory.DirectoryContext('domain',$TargetDomainName, $TargetDomainAdministratorCredential.UserName, $TargetDomainAdministratorCredential.GetNetworkCredential().Password)
+                $trgDomain = [System.DirectoryServices.ActiveDirectory.Domain]::GetDomain($trgDirectoryContext)
+                # Create the source domain object
+                $srcDirectoryContext = New-Object System.DirectoryServices.ActiveDirectory.DirectoryContext('domain',$SourceDomainName)
+                $srcDomain = [System.DirectoryServices.ActiveDirectory.Domain]::GetDomain($srcDirectoryContext)
+            }
+            'Forest'
+            {
+                # Create the target forest object
+                $trgDirectoryContext = New-Object System.DirectoryServices.ActiveDirectory.DirectoryContext('forest',$TargetDomainName, $TargetDomainAdministratorCredential.UserName, $TargetDomainAdministratorCredential.GetNetworkCredential().Password)
+                $trgDomain = [System.DirectoryServices.ActiveDirectory.Forest]::GetForest($trgDirectoryContext)
+                # Create the source forest object
+                $srcDirectoryContext = New-Object System.DirectoryServices.ActiveDirectory.DirectoryContext('forest',$SourceDomainName)
+                $srcDomain = [System.DirectoryServices.ActiveDirectory.Forest]::GetForest($srcDirectoryContext)
+            }
+        }
 
         # Find trust betwen source & destination.
         $trust = $srcDomain.GetTrustRelationship($trgDomain)
@@ -116,7 +130,7 @@ function Set-TargetResource
         [PSCredential]$TargetDomainAdministratorCredential,
 
         [parameter(Mandatory)]
-        [ValidateSet("External")]
+        [ValidateSet("External","Forest")]
         [String]$TrustType,
 
         [parameter(Mandatory)]
@@ -147,7 +161,7 @@ function Test-TargetResource
         [PSCredential]$TargetDomainAdministratorCredential,
 
         [parameter(Mandatory)]
-        [ValidateSet("External")]
+        [ValidateSet("External","Forest")]
         [String]$TrustType,
 
         [parameter(Mandatory)]
@@ -194,7 +208,7 @@ function Validate-ResourceProperties
         [PSCredential]$TargetDomainAdministratorCredential,
 
         [parameter(Mandatory)]
-        [ValidateSet("External")]
+        [ValidateSet("External","Forest")]
         [String]$TrustType,
 
         [parameter(Mandatory)]
@@ -212,13 +226,27 @@ function Validate-ResourceProperties
         $checkingTrustMessage = $($LocalizedData.CheckingTrustMessage) -f $SourceDomainName,$TargetDomainName
         Write-Verbose -Message $checkingTrustMessage
 
-        #Create the target domain object
-        $trgDirectoryContext = New-Object System.DirectoryServices.ActiveDirectory.DirectoryContext('domain',$TargetDomainName, $TargetDomainAdministratorCredential.UserName, $($TargetDomainAdministratorCredential.GetNetworkCredential()).Password)
-        $trgDomain = [System.DirectoryServices.ActiveDirectory.Domain]::GetDomain($trgDirectoryContext)
-
-        # Create the source domain object
-        $srcDirectoryContext = New-Object System.DirectoryServices.ActiveDirectory.DirectoryContext('domain',$SourceDomainName)
-        $srcDomain = [System.DirectoryServices.ActiveDirectory.Domain]::GetDomain($srcDirectoryContext)
+        switch ($TrustType)
+        {
+            'External'
+            {
+                # Create the target domain object
+                $trgDirectoryContext = New-Object System.DirectoryServices.ActiveDirectory.DirectoryContext('domain',$TargetDomainName, $TargetDomainAdministratorCredential.UserName, $TargetDomainAdministratorCredential.GetNetworkCredential().Password)
+                $trgDomain = [System.DirectoryServices.ActiveDirectory.Domain]::GetDomain($trgDirectoryContext)
+                # Create the source domain object
+                $srcDirectoryContext = New-Object System.DirectoryServices.ActiveDirectory.DirectoryContext('domain',$SourceDomainName)
+                $srcDomain = [System.DirectoryServices.ActiveDirectory.Domain]::GetDomain($srcDirectoryContext)
+            }
+            'Forest'
+            {
+                # Create the target forest object
+                $trgDirectoryContext = New-Object System.DirectoryServices.ActiveDirectory.DirectoryContext('forest',$TargetDomainName, $TargetDomainAdministratorCredential.UserName, $TargetDomainAdministratorCredential.GetNetworkCredential().Password)
+                $trgDomain = [System.DirectoryServices.ActiveDirectory.Forest]::GetForest($trgDirectoryContext)
+                # Create the source forest object
+                $srcDirectoryContext = New-Object System.DirectoryServices.ActiveDirectory.DirectoryContext('forest',$SourceDomainName)
+                $srcDomain = [System.DirectoryServices.ActiveDirectory.Forest]::GetForest($srcDirectoryContext)
+            }
+        }
 
         # Find trust
         try
@@ -293,7 +321,7 @@ function Validate-ResourceProperties
                 # Trust type is correct
                 else
                 {
-                    $desiredPropertyMessage = $($LocalizedData.DesiredPropertyMessage) -f 'Trust direction'
+                    $desiredPropertyMessage = $($LocalizedData.DesiredPropertyMessage) -f 'Trust type'
                     Write-Verbose -Message $desiredPropertyMessage
                 }
 

--- a/DSCResources/MSFT_xADDomainTrust/MSFT_xADDomainTrust.schema.mof
+++ b/DSCResources/MSFT_xADDomainTrust/MSFT_xADDomainTrust.schema.mof
@@ -5,7 +5,7 @@ class MSFT_xADDomainTrust : OMI_BaseResource
     [Write, Description("Should this resource be present or absent"), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Required, EmbeddedInstance("MSFT_Credential"), Description("Credentials to authenticate to the target domain")] String TargetDomainAdministratorCredential;
     [Key, Description("Name of the AD domain that is being trusted")] String TargetDomainName;
-    [Required, Description("Type of trust"), ValueMap{"External"}, Values{"External"}] String TrustType;
+    [Required, Description("Type of trust"), ValueMap{"External","Forest"}, Values{"External","Forest"}] String TrustType;
     [Required, Description("Direction of trust"), ValueMap{"Bidirectional","Inbound","Outbound"}, Values{"Bidirectional","Inbound","Outbound"}] String TrustDirection;
     [Key, Description("Name of the AD domain that is requesting the trust")] String SourceDomainName;
 };

--- a/DSCResources/MSFT_xADRecycleBin/Tests/ResourceDesigner.Tests.ps1
+++ b/DSCResources/MSFT_xADRecycleBin/Tests/ResourceDesigner.Tests.ps1
@@ -1,7 +1,7 @@
 Describe 'xADRecycleBin' {
     Context 'xDscResouceDesigner' {
         It 'Pass Test-xDscResource' {
-            Test-xDscResource xADRecycleBin -Verbose | Should Be $True
+            Test-xDscResource -Name ".\DSCResources\MSFT_xADRecycleBin" -Verbose | Should Be $True
         }
 
         It 'Pass Test-xDscSchema' {

--- a/DSCResources/MSFT_xADRecycleBin/Tests/ResourceDesigner.Tests.ps1
+++ b/DSCResources/MSFT_xADRecycleBin/Tests/ResourceDesigner.Tests.ps1
@@ -1,7 +1,11 @@
 Describe 'xADRecycleBin' {
     Context 'xDscResouceDesigner' {
         It 'Pass Test-xDscResource' {
-            Test-xDscResource -Name ".\DSCResources\MSFT_xADRecycleBin" -Verbose | Should Be $True
+            $rootDirectory = Split-Path $pwd.Path -Parent
+            $oldPSModulePath = $env:PSModulePath
+            $env:PSModulePath = $env:PSModulePath + ";" + $rootDirectory
+            Test-xDscResource xADRecycleBin -Verbose | Should Be $True
+            $env:PSModulePath = $oldPSModulePath
         }
 
         It 'Pass Test-xDscSchema' {


### PR DESCRIPTION
Added ability to create Forest trusts and fixed Test-xDscResource path in MSFT_xADRecycleBin\Tests\ResourceDesigner.Tests.ps1.