### PR TITLE
Update MSFT_xADDomain.psm1

### DIFF
--- a/DSCResources/MSFT_xADDomain/MSFT_xADDomain.psm1
+++ b/DSCResources/MSFT_xADDomain/MSFT_xADDomain.psm1
@@ -47,7 +47,7 @@ function Get-TargetResource
             {
                 $dc = Get-ADDomainController -Identity $env:COMPUTERNAME -Credential $DomainAdministratorCredential
                 Write-Verbose -Message "Found domain controller '$($dc.Name)' in domain '$($dc.Domain)'."
-                Write-Verbose -Message "Found parent domain '$($dc.ParentDomain)', expected '$($ParentDomainName)'."
+                Write-Verbose -Message "Found parent domain '$($domain.ParentDomain)', expected '$($ParentDomainName)'."
                 if (($dc.Domain -eq $DomainName) -and ((!($dc.ParentDomain) -and !($ParentDomainName)) -or ($dc.ParentDomain -eq $ParentDomainName)))
                 {
                     Write-Verbose -Message "Current node '$($dc.Name)' is already a domain controller for domain '$($dc.Domain)'."
@@ -230,7 +230,16 @@ function Test-TargetResource
     {
         $parameters = $PSBoundParameters.Remove("Debug");
         $existingResource = Get-TargetResource @PSBoundParameters
-        $existingResource.DomainName -eq $DomainName
+        
+
+        $fullDomainName = $DomainName
+        if ($ParentDomainName)
+        {
+            $fullDomainName = $DomainName + "." + $ParentDomainName
+        }
+
+        Write-Verbose "Checking if $($existingResource.DomainName) matches $fullDomainName : $( ($existingResource.DomainName) -eq $fullDomainName)"
+        $existingResource.DomainName -eq $fullDomainName
     }
     catch
     {
@@ -241,4 +250,3 @@ function Test-TargetResource
 
 
 Export-ModuleMember -Function *-TargetResource
-


### PR DESCRIPTION
Get-TargetResource:
Fixed the Write-Verbose message on line 50: It had the wrong variable for "$dc.ParentDomainName", replaced it with "$domain.ParentDomain"

Test-TargetResource:
Fixed the function always returned false when checking for a child domain with a parent domain. This was happening as Get-TargetResource returns the fully qualified domain name Eg "childdomainname.parent.domain" and the Test-TargetResource was comparing the fully qualified domain name to the child domain name only.