### PR TITLE
Fixed issues with MSFT_xADDomain.psm1

### DIFF
--- a/DSCResources/MSFT_xADDomain/MSFT_xADDomain.psm1
+++ b/DSCResources/MSFT_xADDomain/MSFT_xADDomain.psm1
@@ -230,7 +230,13 @@ function Test-TargetResource
     {
         $parameters = $PSBoundParameters.Remove("Debug");
         $existingResource = Get-TargetResource @PSBoundParameters
-        $existingResource.DomainName -eq $DomainName
+        
+        $fullDomainName = $DomainName
+        if ($ParentDomainName)
+        {
+            $fullDomainName = $DomainName + "." + $ParentDomainName
+        }
+        $existingResource.DomainName -eq $fullDomainName
     }
     catch
     {

--- a/DSCResources/MSFT_xADDomain/MSFT_xADDomain.psm1
+++ b/DSCResources/MSFT_xADDomain/MSFT_xADDomain.psm1
@@ -160,7 +160,7 @@ function Set-TargetResource
         $params = @{
             NewDomainName = $DomainName
             ParentDomainName = $ParentDomainName
-            DomainType = [Microsoft.DirectoryServices.Deployment.Types.DomainType]::ChildDomain
+            DomainType = "ChildDomain"
             SafeModeAdministratorPassword = $SafemodeAdministratorPassword.Password
             Credential = $DomainAdministratorCredential
             InstallDns = $true

--- a/DSCResources/MSFT_xADDomain/MSFT_xADDomain.psm1
+++ b/DSCResources/MSFT_xADDomain/MSFT_xADDomain.psm1
@@ -131,7 +131,7 @@ function Set-TargetResource
         }
         if ($DomainNetbiosName.length -gt 0)
         {
-            $params.Add("DomainNetbiosName", $DomainNetbiosName)
+            $params.Add("NewDomainNetbiosName", $DomainNetbiosName)
         }
         if ($DnsDelegationCredential -ne $null)
         {
@@ -167,9 +167,9 @@ function Set-TargetResource
             NoRebootOnCompletion = $true
             Force = $true
         }
-        if ($DomainNetbiosName -ne $null)
+        if ($DomainNetbiosName.length -gt 0)
         {
-            $params.Add("DomainNetbiosName", $DomainNetbiosName)
+            $params.Add("NewDomainNetbiosName", $DomainNetbiosName)
         }
         if ($DnsDelegationCredential -ne $null)
         {

--- a/DSCResources/MSFT_xADDomain/MSFT_xADDomain.psm1
+++ b/DSCResources/MSFT_xADDomain/MSFT_xADDomain.psm1
@@ -129,7 +129,7 @@ function Set-TargetResource
             NoRebootOnCompletion = $true
             Force = $true
         }
-        if ($DomainNetbiosName -ne $null)
+        if ($DomainNetbiosName.length -gt 0)
         {
             $params.Add("DomainNetbiosName", $DomainNetbiosName)
         }

--- a/DSCResources/MSFT_xADDomain/MSFT_xADDomain.psm1
+++ b/DSCResources/MSFT_xADDomain/MSFT_xADDomain.psm1
@@ -47,7 +47,7 @@ function Get-TargetResource
             {
                 $dc = Get-ADDomainController -Identity $env:COMPUTERNAME -Credential $DomainAdministratorCredential
                 Write-Verbose -Message "Found domain controller '$($dc.Name)' in domain '$($dc.Domain)'."
-                Write-Verbose -Message "Found parent domain '$($dc.ParentDomain)', expected '$($ParentDomainName)'."
+                Write-Verbose -Message "Found parent domain '$($domain.ParentDomain)', expected '$($ParentDomainName)'."
                 if (($dc.Domain -eq $DomainName) -and ((!($dc.ParentDomain) -and !($ParentDomainName)) -or ($dc.ParentDomain -eq $ParentDomainName)))
                 {
                     Write-Verbose -Message "Current node '$($dc.Name)' is already a domain controller for domain '$($dc.Domain)'."


### PR DESCRIPTION
- Fixed invalid domain type when deploying a child domain on windows server 2012r2 I get the following error:
*VERBOSE: [2015-07-24T12:40:29] [ERROR] Unable to find type [Microsoft.DirectoryServices.Deployment.Types.DomainType]*
- Modified "DomainType" parameter to a valid string as shown in here:
https://technet.microsoft.com/en-us/library/hh974722(v=wps.630).aspx

- Invalid parameter "DomainNetbiosName"
   - The cmdlet Install-ADDSDomain does not contain a parameter named "DomainNetbiosName", it should be "NewDomainNetbiosName" as shown here:
https://technet.microsoft.com/en-us/library/hh974722(v=wps.630).aspx

VERBOSE: [2015-07-24T12:44:04] [ERROR] A parameter cannot be found that matches parameter name 'DomainNetbiosName'

- There is a flawed "if" statement on Line 132 - always returns $true and adds DomainNetbiosName to the parameter hash table even if it is an empty string as it has been declared as a parameter, as this is a non-mandatory parameter this logic is broken and can lead to failures. Modified the statement to test on string length.