### PR TITLE
Added DNS flush in retry loop

### DIFF
--- a/DSCResources/MSFT_xWaitForADDomain/MSFT_xWaitForADDomain.psm1
+++ b/DSCResources/MSFT_xWaitForADDomain/MSFT_xWaitForADDomain.psm1
@@ -57,6 +57,7 @@ function Set-TargetResource
         {
             Write-Verbose -Message "Domain $DomainName not found. Will retry again after $RetryIntervalSec sec"
             Start-Sleep -Seconds $RetryIntervalSec
+            Clear-DnsClientCache
         }
     }
 


### PR DESCRIPTION
Due to the DNS client cache the retry loop is ineffective - if the domain did not exist this can be cached which prevents the retry loop from proceeding even once the domain is present. Flushing the DNS client cache between each retry avoids this.