### PR TITLE
Merges xADOrganizationalUnit from PS Gallery

### DIFF
--- a/DSCResources/MSFT_xADOrganizationalUnit/MSFT_xADOrganizationalUnit.psm1
+++ b/DSCResources/MSFT_xADOrganizationalUnit/MSFT_xADOrganizationalUnit.psm1
@@ -69,7 +69,7 @@ function Test-TargetResource
         [System.String]
         $Ensure = 'Present',
 
-        [parameter(Mandatory)] 
+        [ValidateNotNull()]
         [System.Management.Automation.PSCredential] $Credential,
 
         [ValidateNotNull()]
@@ -149,7 +149,7 @@ function Set-TargetResource
         [System.String]
         $Ensure = 'Present',
 
-        [parameter(Mandatory)] 
+        [ValidateNotNull()]
         [System.Management.Automation.PSCredential] $Credential,
 
         [ValidateNotNull()]
@@ -170,23 +170,56 @@ function Set-TargetResource
         if ($Ensure -eq 'Present')
         {
             Write-Verbose ($LocalizedData.UpdatingOU -f $targetResource.Name)
-            Set-ADOrganizationalUnit -Identity $ou -Credential $Credential -Description $Description -ProtectedFromAccidentalDeletion ($ProtectedFromAccidentalDeletion -eq 'Yes')
+            $setADOrganizationalUnitParams = @{
+                Identity = $ou
+                Description = $Description
+                ProtectedFromAccidentalDeletion = ($ProtectedFromAccidentalDeletion -eq 'Yes')
+            }
+            if ($Credential)
+            {
+                $setADOrganizationalUnitParams['Credential'] = $Credential
+            }
+            Set-ADOrganizationalUnit @setADOrganizationalUnitParams
         }
         else
         {
             Write-Verbose ($LocalizedData.DeletingOU -f $targetResource.Name)
             if ($targetResource.ProtectedFromAccidentalDeletion -eq 'Yes')
             {
-                Set-ADOrganizationalUnit -Identity $ou -Credential $Credential -ProtectedFromAccidentalDeletion $false
+                $setADOrganizationalUnitParams = @{
+                    Identity = $ou
+                    ProtectedFromAccidentalDeletion = ($ProtectedFromAccidentalDeletion -eq 'Yes')
+                }
+                if ($Credential)
+                {
+                    $setADOrganizationalUnitParams['Credential'] = $Credential
+                }
+                Set-ADOrganizationalUnit @setADOrganizationalUnitParams
             }
 
-            Remove-ADOrganizationalUnit -Identity $ou -Credential $Credential 
+            $removeADOrganizationalUnitParams = @{
+                Identity = $ou
+            }
+            if ($Credential)
+            {
+                $removeADOrganizationalUnitParams['Credential'] = $Credential
+            }
+            Remove-ADOrganizationalUnit @removeADOrganizationalUnitParams
         }
     }
     else
     {
         Write-Verbose ($LocalizedData.CreatingOU -f $targetResource.Name)
-        New-ADOrganizationalUnit -Credential $Credential -Name $Name -Path $Path -Description $Description -ProtectedFromAccidentalDeletion ($ProtectedFromAccidentalDeletion -eq "Yes")
+        $newADOrganizationalUnitParams = @{
+            Name = $Name
+            Path = $Path
+            Description = $Description
+            ProtectedFromAccidentalDeletion = ($ProtectedFromAccidentalDeletion -eq "Yes")
+        }
+        if ($Credential) {
+            $newADOrganizationalUnitParams['Credential'] = $Credential
+        }
+        New-ADOrganizationalUnit @newADOrganizationalUnitParams
     }
 
 } #end function Set-TargetResource

--- a/DSCResources/MSFT_xADOrganizationalUnit/MSFT_xADOrganizationalUnit.psm1
+++ b/DSCResources/MSFT_xADOrganizationalUnit/MSFT_xADOrganizationalUnit.psm1
@@ -1,0 +1,211 @@
+<#
+Introduction
+
+The xOu module is a part of the ALM Ranger DevOps solutions (vsardevops.codeplex.com), which consists of code as config guidance, quick reference posters and supporting resources.
+This module contains the xAdOrganizationalUnit resource. This resource allows configuration of Organizational Units (OUs) in Active Directory (AD).
+#>
+
+# Localized messages
+data LocalizedData
+{
+    # culture="en-US"
+    ConvertFrom-StringData @'
+RoleNotFoundError        = Please ensure that the PowerShell module for role '{0}' is installed
+UpdatingOU               = Updating OU '{0}'
+DeletingOU               = Deleting OU '{0}'
+CreatingOU               = Creating OU '{0}'
+OUInDesiredState         = OU '{0}' exists and is in the desired state
+OUNotInDesiredState      = OU '{0}' exists but is not in the desired state
+OUExistsButShouldNot     = OU '{0}' exists when it should not exist
+OUDoesNotExistButShould  = OU '{0}' does not exist when it should exist
+'@
+}
+
+function Get-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param
+    (    
+        [parameter(Mandatory)] 
+        [System.String] $Name,
+
+        [parameter(Mandatory)] 
+        [System.String] $Path
+    )
+    
+    Assert-Module -ModuleName 'ActiveDirectory';
+    $ou = Get-ADOrganizationalUnit -Filter { Name -eq $Name } -SearchBase $Path -SearchScope OneLevel -Properties ProtectedFromAccidentalDeletion, Description
+
+    $targetResource = @{
+        Name = $Name
+        Path = $Path
+        Ensure = 'Present'
+        ProtectedFromAccidentalDeletion = if ($ou.ProtectedFromAccidentalDeletion) { 'Yes' } else { 'No' }
+        Description = $ou.Description
+    }
+
+    if ($ou -eq $null) {
+        $targetResource['Ensure'] = 'Absent'
+    }
+
+    return $targetResource
+
+} # end function Get-TargetResource
+
+function Test-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([Boolean])]
+    param
+    (    
+        [parameter(Mandatory)] 
+        [System.String] $Name,
+
+        [parameter(Mandatory)] 
+        [System.String] $Path,
+        
+        [ValidateSet('Present', 'Absent')]
+        [System.String]
+        $Ensure = 'Present',
+
+        [parameter(Mandatory)] 
+        [System.Management.Automation.PSCredential] $Credential,
+
+        [ValidateNotNull()]
+        [ValidateSet('No', 'Yes')]
+        [System.String] $ProtectedFromAccidentalDeletion = 'Yes',
+
+        [ValidateNotNull()]
+        [System.String]
+        $Description = ''
+    )
+
+    $targetResource = Get-TargetResource -Name $Name -Path $Path
+    
+    if ($targetResource.Ensure -eq 'Present')
+    {
+        if ($Ensure -eq 'Present')
+        {
+            ## Organizational unit exists
+            if ([System.String]::IsNullOrEmpty($Description)) {
+                $isCompliant = (($targetResource.Name -eq $Name) -and
+                                    ($targetResource.Path -eq $Path) -and
+                                        ($targetResource.ProtectedFromAccidentalDeletion -eq $ProtectedFromAccidentalDeletion))
+            }
+            else {
+                $isCompliant = (($targetResource.Name -eq $Name) -and
+                                    ($targetResource.Path -eq $Path) -and
+                                        ($targetResource.ProtectedFromAccidentalDeletion -eq $ProtectedFromAccidentalDeletion) -and
+                                            ($targetResource.Description -eq $Description))
+            }
+
+            if ($isCompliant)
+            {
+                Write-Verbose ($LocalizedData.OUInDesiredState -f $targetResource.Name)
+            }
+            else
+            {
+                Write-Verbose ($LocalizedData.OUNotInDesiredState -f $targetResource.Name)
+            }
+        }
+        else
+        {
+            $isCompliant = $false
+            Write-Verbose ($LocalizedData.OUExistsButShouldNot -f $targetResource.Name)
+        }
+    }
+    else
+    {
+        ## Organizational unit does not exist
+        if ($Ensure -eq 'Present')
+        {
+            $isCompliant = $false
+            Write-Verbose ($LocalizedData.OUDoesNotExistButShould -f $targetResource.Name)
+        }
+        else
+        {
+            $isCompliant = $true
+            Write-Verbose ($LocalizedData.OUInDesiredState -f $targetResource.Name)
+        }
+    }
+
+    return $isCompliant
+
+} #end function Test-TargetResource
+
+function Set-TargetResource
+{
+    [CmdletBinding()]
+    param
+    (    
+        [parameter(Mandatory)] 
+        [System.String] $Name,
+
+        [parameter(Mandatory)] 
+        [System.String] $Path,
+        
+        [ValidateSet('Present', 'Absent')]
+        [System.String]
+        $Ensure = 'Present',
+
+        [parameter(Mandatory)] 
+        [System.Management.Automation.PSCredential] $Credential,
+
+        [ValidateNotNull()]
+        [ValidateSet('No', 'Yes')]
+        [System.String] $ProtectedFromAccidentalDeletion = 'Yes',
+
+        [ValidateNotNull()]
+        [System.String]
+        $Description = ''
+    )
+
+    Assert-Module -ModuleName 'ActiveDirectory';
+    $targetResource = Get-TargetResource -Name $Name -Path $Path
+    
+    if ($targetResource.Ensure -eq 'Present')
+    {
+        $ou = Get-ADOrganizationalUnit -Filter { Name -eq $Name } -SearchBase $Path -SearchScope OneLevel
+        if ($Ensure -eq 'Present')
+        {
+            Write-Verbose ($LocalizedData.UpdatingOU -f $targetResource.Name)
+            Set-ADOrganizationalUnit -Identity $ou -Credential $Credential -Description $Description -ProtectedFromAccidentalDeletion ($ProtectedFromAccidentalDeletion -eq 'Yes')
+        }
+        else
+        {
+            Write-Verbose ($LocalizedData.DeletingOU -f $targetResource.Name)
+            if ($targetResource.ProtectedFromAccidentalDeletion -eq 'Yes')
+            {
+                Set-ADOrganizationalUnit -Identity $ou -Credential $Credential -ProtectedFromAccidentalDeletion $false
+            }
+
+            Remove-ADOrganizationalUnit -Identity $ou -Credential $Credential 
+        }
+    }
+    else
+    {
+        Write-Verbose ($LocalizedData.CreatingOU -f $targetResource.Name)
+        New-ADOrganizationalUnit -Credential $Credential -Name $Name -Path $Path -Description $Description -ProtectedFromAccidentalDeletion ($ProtectedFromAccidentalDeletion -eq "Yes")
+    }
+
+} #end function Set-TargetResource
+
+# Internal function to assert if the role specific module is installed or not
+function Assert-Module
+{
+    [CmdletBinding()]
+    param (
+        [System.String] $ModuleName = 'ActiveDirectory'
+    )
+
+    if (-not (Get-Module -Name $ModuleName -ListAvailable))
+    {
+        $errorMsg = $($LocalizedData.RoleNotFoundError) -f $moduleName;
+        $exception = New-Object System.InvalidOperationException $errorMessage;
+        $errorRecord = New-Object System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $null;
+        throw $errorRecord;
+    }
+} #end function Assert-Module
+
+Export-ModuleMember -Function *-TargetResource

--- a/DSCResources/MSFT_xADOrganizationalUnit/MSFT_xADOrganizationalUnit.psm1
+++ b/DSCResources/MSFT_xADOrganizationalUnit/MSFT_xADOrganizationalUnit.psm1
@@ -1,10 +1,3 @@
-<#
-Introduction
-
-The xOu module is a part of the ALM Ranger DevOps solutions (vsardevops.codeplex.com), which consists of code as config guidance, quick reference posters and supporting resources.
-This module contains the xAdOrganizationalUnit resource. This resource allows configuration of Organizational Units (OUs) in Active Directory (AD).
-#>
-
 # Localized messages
 data LocalizedData
 {
@@ -40,15 +33,10 @@ function Get-TargetResource
     $targetResource = @{
         Name = $Name
         Path = $Path
-        Ensure = 'Present'
-        ProtectedFromAccidentalDeletion = if ($ou.ProtectedFromAccidentalDeletion) { 'Yes' } else { 'No' }
+        Ensure = if ($null -eq $ou) { 'Absent' } else { 'Present' }
+        ProtectedFromAccidentalDeletion = $ou.ProtectedFromAccidentalDeletion
         Description = $ou.Description
     }
-
-    if ($ou -eq $null) {
-        $targetResource['Ensure'] = 'Absent'
-    }
-
     return $targetResource
 
 } # end function Get-TargetResource
@@ -73,8 +61,7 @@ function Test-TargetResource
         [System.Management.Automation.PSCredential] $Credential,
 
         [ValidateNotNull()]
-        [ValidateSet('No', 'Yes')]
-        [System.String] $ProtectedFromAccidentalDeletion = 'Yes',
+        [System.Boolean] $ProtectedFromAccidentalDeletion = $true,
 
         [ValidateNotNull()]
         [System.String]
@@ -153,8 +140,7 @@ function Set-TargetResource
         [System.Management.Automation.PSCredential] $Credential,
 
         [ValidateNotNull()]
-        [ValidateSet('No', 'Yes')]
-        [System.String] $ProtectedFromAccidentalDeletion = 'Yes',
+        [System.Boolean] $ProtectedFromAccidentalDeletion = $true,
 
         [ValidateNotNull()]
         [System.String]
@@ -173,7 +159,7 @@ function Set-TargetResource
             $setADOrganizationalUnitParams = @{
                 Identity = $ou
                 Description = $Description
-                ProtectedFromAccidentalDeletion = ($ProtectedFromAccidentalDeletion -eq 'Yes')
+                ProtectedFromAccidentalDeletion = $ProtectedFromAccidentalDeletion
             }
             if ($Credential)
             {
@@ -184,11 +170,11 @@ function Set-TargetResource
         else
         {
             Write-Verbose ($LocalizedData.DeletingOU -f $targetResource.Name)
-            if ($targetResource.ProtectedFromAccidentalDeletion -eq 'Yes')
+            if ($targetResource.ProtectedFromAccidentalDeletion)
             {
                 $setADOrganizationalUnitParams = @{
                     Identity = $ou
-                    ProtectedFromAccidentalDeletion = ($ProtectedFromAccidentalDeletion -eq 'Yes')
+                    ProtectedFromAccidentalDeletion = $ProtectedFromAccidentalDeletion
                 }
                 if ($Credential)
                 {
@@ -214,7 +200,7 @@ function Set-TargetResource
             Name = $Name
             Path = $Path
             Description = $Description
-            ProtectedFromAccidentalDeletion = ($ProtectedFromAccidentalDeletion -eq "Yes")
+            ProtectedFromAccidentalDeletion = $ProtectedFromAccidentalDeletion
         }
         if ($Credential) {
             $newADOrganizationalUnitParams['Credential'] = $Credential

--- a/DSCResources/MSFT_xADOrganizationalUnit/MSFT_xADOrganizationalUnit.schema.mof
+++ b/DSCResources/MSFT_xADOrganizationalUnit/MSFT_xADOrganizationalUnit.schema.mof
@@ -1,0 +1,12 @@
+[ClassVersion("1.0.0.0"), FriendlyName("xADOrganizationalUnit")] 
+class MSFT_xADOrganizationalUnit : OMI_BaseResource
+{
+    [Key, Description("The name of OU")] string Name;
+    [Key, Description("Specifies the X500 path of the OU or container where the new object is created")] string Path;
+    [Write, ValueMap{"Present", "Absent"}, Values{"Present", "Absent"}] string Ensure;
+
+    [Write, EmbeddedInstance("MSFT_Credential"),Description("The credential to be used to perform the operation on Active Directory")] string Credential;
+    [Write, ValueMap{"Yes", "No"}, Values{"Yes", "No"},Description("Defaults to Yes")] string ProtectedFromAccidentalDeletion;
+    [Write, Description("The description of the OU")] string Description;
+};
+

--- a/DSCResources/MSFT_xADOrganizationalUnit/MSFT_xADOrganizationalUnit.schema.mof
+++ b/DSCResources/MSFT_xADOrganizationalUnit/MSFT_xADOrganizationalUnit.schema.mof
@@ -6,7 +6,7 @@ class MSFT_xADOrganizationalUnit : OMI_BaseResource
    
     [Write, ValueMap{"Present", "Absent"}, Values{"Present", "Absent"}] string Ensure;
     [Write, EmbeddedInstance("MSFT_Credential"),Description("The credential to be used to perform the operation on Active Directory")] string Credential;
-    [Write, ValueMap{"Yes", "No"}, Values{"Yes", "No"},Description("Defaults to Yes")] string ProtectedFromAccidentalDeletion;
+    [Write, Description("Defaults to True")] boolean ProtectedFromAccidentalDeletion;
     [Write, Description("The description of the OU")] string Description;
 };
 

--- a/DSCResources/MSFT_xADOrganizationalUnit/MSFT_xADOrganizationalUnit.schema.mof
+++ b/DSCResources/MSFT_xADOrganizationalUnit/MSFT_xADOrganizationalUnit.schema.mof
@@ -3,8 +3,8 @@ class MSFT_xADOrganizationalUnit : OMI_BaseResource
 {
     [Key, Description("The name of OU")] string Name;
     [Key, Description("Specifies the X500 path of the OU or container where the new object is created")] string Path;
-    [Write, ValueMap{"Present", "Absent"}, Values{"Present", "Absent"}] string Ensure;
-
+   
+	[Write, ValueMap{"Present", "Absent"}, Values{"Present", "Absent"}] string Ensure;
     [Write, EmbeddedInstance("MSFT_Credential"),Description("The credential to be used to perform the operation on Active Directory")] string Credential;
     [Write, ValueMap{"Yes", "No"}, Values{"Yes", "No"},Description("Defaults to Yes")] string ProtectedFromAccidentalDeletion;
     [Write, Description("The description of the OU")] string Description;

--- a/DSCResources/MSFT_xADOrganizationalUnit/MSFT_xADOrganizationalUnit.schema.mof
+++ b/DSCResources/MSFT_xADOrganizationalUnit/MSFT_xADOrganizationalUnit.schema.mof
@@ -4,7 +4,7 @@ class MSFT_xADOrganizationalUnit : OMI_BaseResource
     [Key, Description("The name of OU")] string Name;
     [Key, Description("Specifies the X500 path of the OU or container where the new object is created")] string Path;
    
-	[Write, ValueMap{"Present", "Absent"}, Values{"Present", "Absent"}] string Ensure;
+    [Write, ValueMap{"Present", "Absent"}, Values{"Present", "Absent"}] string Ensure;
     [Write, EmbeddedInstance("MSFT_Credential"),Description("The credential to be used to perform the operation on Active Directory")] string Credential;
     [Write, ValueMap{"Yes", "No"}, Values{"Yes", "No"},Description("Defaults to Yes")] string ProtectedFromAccidentalDeletion;
     [Write, Description("The description of the OU")] string Description;

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The xADOrganizational Unit DSC resource will manage OUs within Active Directory.
 * **Name**: Name of the Active Directory organizational unit to manage.
 * **Path**: Specified the X500 (DN) path of the organizational unit's parent object.
 * **Description**: The OU description property (optional).
-* **ProtectedFromAccidentalDeletion**: Valid values are 'Yes' and 'No'. If not specified, it defaults to 'Yes'.
+* **ProtectedFromAccidentalDeletion**: Valid values are $true and $false. If not specified, it defaults to $true.
 * **Ensure**: Specifies whether the OU is present or absent. Valid values are 'Present' and 'Absent'. It not specified, it defaults to 'Present'.
 * **Credential**: User account credentials used to perform the operation . Note: _if not running on a domain controller, this is required_.
 
@@ -799,9 +799,8 @@ Param(
     [System.String]
     $Path,
     
-    [ValidateSet('Yes','No')]    
-    [System.String]
-    $ProtectedFromAccidentalDeletion = 'Yes',
+    [System.Boolean]
+    $ProtectedFromAccidentalDeletion = $true,
     
     [ValidateNotNull()]
     [System.String]

--- a/README.md
+++ b/README.md
@@ -86,7 +86,21 @@ __Note: This resource does not currently manage group membership.__
 * **DomainController**: An existing Active Directory domain controller used to perform the operation (optional). Note: if not running on a domain controller, this is required.
 * **Credential**: User account credentials used to perform the operation (optional). Note: if not running on a domain controller, this is required.
 
+### xADOrganizationalUnit
+The xADOrganizational Unit DSC resource will manage OUs within Active Directory.
+* **Name**: Name of the Active Directory organizational unit to manage.
+* **Path**: Specified the X500 (DN) path of the organizational unit's parent object.
+* **Description**: The OU description property (optional).
+* **ProtectedFromAccidentalDeletion**: Valid values are 'Yes' and 'No'. If not specified, it defaults to 'Yes'.
+* **Ensure**: Specifies whether the OU is present or absent. Valid values are 'Present' and 'Absent'. It not specified, it defaults to 'Present'.
+* **Credential**: User account credentials used to perform the operation . Note: if not running on a domain controller, this is required.
+
 ## Versions
+
+### Unreleased
+
+* Added xADGroup resource
+* Merged xADOrganizationalUnit resource from the PowerShell gallery
 
 ### 2.7.0.0
 
@@ -763,4 +777,50 @@ Param(
 Example_xADGroup -GroupName 'TestGroup' -Scope 'DomainLocal' -Description 'Example test domain local security group' -ConfigurationData $ConfigurationData
 
 Start-DscConfiguration -Path .\Example_xADGroup -Wait -Verbose
+```
+
+### Create an Active Directory organizational unit
+
+In this example, we add an Active Directory organizational unit to the 'example.com' domain root.
+
+```powershell
+configuration Example_xADOrganizationalUnit
+{
+Param(
+    [parameter(Mandatory = $true)]
+    [System.String]
+    $Name,
+    
+    [parameter(Mandatory = $true)]    
+    [System.String]
+    $Path,
+    
+    [ValidateSet('Yes','No')]    
+    [System.String]
+    $ProtectedFromAccidentalDeletion = 'Yes',
+    
+    [ValidateNotNull()]
+    [System.String]
+    $Description = ''
+)
+
+    Import-DscResource -Module xActiveDirectory
+
+    Node $AllNodes.NodeName
+    {
+        xADOrganizationalUnit ExampleOU
+        {
+           Name = $Name
+           Path = $Path
+           ProtectedFromAccidentalDeletion = $ProtectedFromAccidentalDeletion
+           Description = $Description
+           Ensure = 'Present'
+        }
+    }
+}
+
+Example_xADOrganizationalUnit -Name 'Example OU' -Path 'dc=example,dc=com' -Description 'Example test organizational unit' -ConfigurationData $ConfigurationData
+
+Start-DscConfiguration -Path .\Example_xADOrganizationalUnit -Wait -Verbose
+
 ```

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Please check out common DSC Resource [contributing guidelines](https://github.co
 
 ## Description
 
-The **xActiveDirectory** module contains the **xADDomain, xADDomainController, xADUser, xWaitForDomain, and ADDomainTrust** DSC Resources.
-These DSC Resources allow you to configure new domains, child domains, and high availability domain controllers and establish cross-domain trusts.
+The **xActiveDirectory** module contains the **xADDomain, xADDomainController, xADUser, xWaitForDomain, xADDomainTrust, xADRecycleBin, xADGroup and xADOrganizationalUnit** DSC Resources.
+These DSC Resources allow you to configure new domains, child domains, and high availability domain controllers, establish cross-domain trusts and manage users, groups and OUs.
 
 ## Resources
 
@@ -20,7 +20,9 @@ These DSC Resources allow you to configure new domains, child domains, and high 
 * **xADUser** modifies and removes Active Directory Users. 
 * **xWaitForDomain** waits for new, remote domain to setup.
 (Note: the RSAT tools will not be installed when these resources are used to configure AD.)
-* **xADDomainTrust** establishes cross-domain trusts
+* **xADDomainTrust** establishes cross-domain trusts.
+* **xADGroup** modifies and removes Active Directory groups.
+* **xADOrganizationalUnit** creates and deletes Active Directory OUs.
 
 ### **xADDomain**
 
@@ -84,7 +86,7 @@ __Note: This resource does not currently manage group membership.__
 * **DisplayName**: The group display name property (optional).
 * **Ensure**: Specifies whether the group is present or absent. Valid values are 'Present' and 'Absent'. It not specified, it defaults to 'Present'.
 * **DomainController**: An existing Active Directory domain controller used to perform the operation (optional). Note: if not running on a domain controller, this is required.
-* **Credential**: User account credentials used to perform the operation (optional). Note: if not running on a domain controller, this is required.
+* **Credential**: User account credentials used to perform the operation (optional). Note: _if not running on a domain controller, this is required_.
 
 ### xADOrganizationalUnit
 The xADOrganizational Unit DSC resource will manage OUs within Active Directory.
@@ -93,7 +95,7 @@ The xADOrganizational Unit DSC resource will manage OUs within Active Directory.
 * **Description**: The OU description property (optional).
 * **ProtectedFromAccidentalDeletion**: Valid values are 'Yes' and 'No'. If not specified, it defaults to 'Yes'.
 * **Ensure**: Specifies whether the OU is present or absent. Valid values are 'Present' and 'Absent'. It not specified, it defaults to 'Present'.
-* **Credential**: User account credentials used to perform the operation . Note: if not running on a domain controller, this is required.
+* **Credential**: User account credentials used to perform the operation . Note: _if not running on a domain controller, this is required_.
 
 ## Versions
 
@@ -779,7 +781,7 @@ Example_xADGroup -GroupName 'TestGroup' -Scope 'DomainLocal' -Description 'Examp
 Start-DscConfiguration -Path .\Example_xADGroup -Wait -Verbose
 ```
 
-### Create an Active Directory organizational unit
+### Create an Active Directory OU
 
 In this example, we add an Active Directory organizational unit to the 'example.com' domain root.
 

--- a/Tests/xADOrganizationalUnit.Tests.ps1
+++ b/Tests/xADOrganizationalUnit.Tests.ps1
@@ -30,7 +30,6 @@ Describe 'xADOrganizationalUnit' {
             Path = 'OU=Fake,DC=contoso,DC=com';
             Description = 'Test AD OU description';
             Ensure = 'Present';
-            #Credential = $testCredential;
         }
         
         $testAbsentParams = $testPresentParams.Clone();
@@ -44,7 +43,7 @@ Describe 'xADOrganizationalUnit' {
 
         Context "Validate Get-TargetResource method" {
 
-            It 'Returns a "System.Collections.Hashtable" type' {
+            It 'Returns a "System.Collections.Hashtable" object type' {
                 Mock Assert-Module -MockWith { }
                 Mock Get-ADOrganizationalUnit -MockWith { return [PSCustomObject] $protectedFakeAdOu }
                 $targetResource = Get-TargetResource -Name $testPresentParams.Name -Path $testPresentParams.Path
@@ -68,15 +67,15 @@ Describe 'xADOrganizationalUnit' {
                 $targetResource.Ensure | Should Be 'Absent'
             }
 
-            It 'Returns "ProtectedFromAccidentalDeletion" = "Yes" when OU is protected' {
+            It 'Returns "ProtectedFromAccidentalDeletion" = "$true" when OU is protected' {
                 Mock Assert-Module -MockWith { }
                 Mock Get-ADOrganizationalUnit -MockWith { return [PSCustomObject] $protectedFakeAdOu }
                 $targetResource = Get-TargetResource -Name $testPresentParams.Name -Path $testPresentParams.Path
                 
-                $targetResource.ProtectedFromAccidentalDeletion | Should Be 'Yes'
+                $targetResource.ProtectedFromAccidentalDeletion | Should Be $true
             }
 
-            It 'Returns "ProtectedFromAccidentalDeletion" = "No" when OU is not protected' {
+            It 'Returns "ProtectedFromAccidentalDeletion" = "$false" when OU is not protected' {
                 Mock Assert-Module -MockWith { }
                 Mock Get-ADOrganizationalUnit -MockWith {
                     $unprotectedFakeAdOu = $protectedFakeAdOu.Clone();
@@ -85,7 +84,7 @@ Describe 'xADOrganizationalUnit' {
                 }
                 $targetResource = Get-TargetResource -Name $testPresentParams.Name -Path $testPresentParams.Path
                 
-                $targetResource.ProtectedFromAccidentalDeletion | Should Be 'No'
+                $targetResource.ProtectedFromAccidentalDeletion | Should Be $false
             }
 
             It 'Returns an empty description' {
@@ -105,7 +104,7 @@ Describe 'xADOrganizationalUnit' {
         
         Context "Validate Test-TargetResource method" {
 
-            It 'Returns a "System.Boolean" type' {
+            It 'Returns a "System.Boolean" object type' {
                 Mock Assert-Module -MockWith { }
                 Mock Get-ADOrganizationalUnit { return [PSCustomObject] $protectedFakeAdOu }
                 $targetResource = Test-TargetResource @testPresentParams
@@ -140,7 +139,7 @@ Describe 'xADOrganizationalUnit' {
                 Mock Assert-Module -MockWith { }
                 Mock Get-ADOrganizationalUnit { return [PSCustomObject] $protectedFakeAdOu }
                 $testProtectedFromAccidentalDeletionParams = $testPresentParams.Clone()
-                $testProtectedFromAccidentalDeletionParams['ProtectedFromAccidentalDeletion'] = 'No'
+                $testProtectedFromAccidentalDeletionParams['ProtectedFromAccidentalDeletion'] = $false
                 
                 Test-TargetResource @testProtectedFromAccidentalDeletionParams | Should Be $false
             }

--- a/Tests/xADOrganizationalUnit.Tests.ps1
+++ b/Tests/xADOrganizationalUnit.Tests.ps1
@@ -1,0 +1,235 @@
+[CmdletBinding()]
+param()
+
+if (!$PSScriptRoot) # $PSScriptRoot is not defined in 2.0
+{
+    $PSScriptRoot = [System.IO.Path]::GetDirectoryName($MyInvocation.MyCommand.Path)
+}
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$RepoRoot = (Resolve-Path $PSScriptRoot\..).Path
+
+$ModuleName = 'MSFT_xADOrganizationalUnit'
+Import-Module (Join-Path $RepoRoot "DSCResources\$ModuleName\$ModuleName.psm1") -Force;
+
+Describe 'xADOrganizationalUnit' {
+    
+    InModuleScope $ModuleName {
+
+        function Get-ADOrganizationalUnit { param ($Name) }
+        function Set-ADOrganizationalUnit { param ($Identity) }
+        function Remove-ADOrganizationalUnit { param ($Name) }
+        function New-ADOrganizationalUnit { param ($Name) }
+
+        $testCredentials = New-Object System.Management.Automation.PSCredential 'DummyUser', (ConvertTo-SecureString 'DummyPassword' -AsPlainText -Force);
+
+        $testPresentParams = @{
+            Name = 'TestOU'
+            Path = 'OU=Fake,DC=contoso,DC=com';
+            Description = 'Test AD OU description';
+            Ensure = 'Present';
+            Credential = $testCredentials;
+        }
+        
+        $testAbsentParams = $testPresentParams.Clone();
+        $testAbsentParams['Ensure'] = 'Absent';
+        
+        $protectedFakeAdOu = @{
+            Name = $testPresentParams.Name;
+            ProtectedFromAccidentalDeletion = $true;
+            Description = $testPresentParams.Description;
+        }
+
+        Context "Validate Get-TargetResource method" {
+
+            It 'Returns a "System.Collections.Hashtable" type' {
+                Mock Assert-Module -MockWith { }
+                Mock Get-ADOrganizationalUnit -MockWith { return [PSCustomObject] $protectedFakeAdOu }
+                $targetResource = Get-TargetResource -Name $testPresentParams.Name -Path $testPresentParams.Path
+                
+                $targetResource -is [System.Collections.Hashtable] | Should Be $true
+            }
+
+            It 'Returns "Ensure" = "Present" when OU exists' {
+                Mock Assert-Module -MockWith { }
+                Mock Get-ADOrganizationalUnit -MockWith { return [PSCustomObject] $protectedFakeAdOu }
+                $targetResource = Get-TargetResource -Name $testPresentParams.Name -Path $testPresentParams.Path
+                
+                $targetResource.Ensure | Should Be 'Present'
+            }
+
+            It 'Returns "Ensure" = "Absent" when OU does not exist' {
+                Mock Assert-Module -MockWith { }
+                Mock Get-ADOrganizationalUnit -MockWith { }
+                $targetResource = Get-TargetResource -Name $testPresentParams.Name -Path $testPresentParams.Path
+                
+                $targetResource.Ensure | Should Be 'Absent'
+            }
+
+            It 'Returns "ProtectedFromAccidentalDeletion" = "Yes" when OU is protected' {
+                Mock Assert-Module -MockWith { }
+                Mock Get-ADOrganizationalUnit -MockWith { return [PSCustomObject] $protectedFakeAdOu }
+                $targetResource = Get-TargetResource -Name $testPresentParams.Name -Path $testPresentParams.Path
+                
+                $targetResource.ProtectedFromAccidentalDeletion | Should Be 'Yes'
+            }
+
+            It 'Returns "ProtectedFromAccidentalDeletion" = "No" when OU is not protected' {
+                Mock Assert-Module -MockWith { }
+                Mock Get-ADOrganizationalUnit -MockWith {
+                    $unprotectedFakeAdOu = $protectedFakeAdOu.Clone();
+                    $unprotectedFakeAdOu['ProtectedFromAccidentalDeletion'] = $false;
+                    return [PSCustomObject] $unprotectedFakeAdOu
+                }
+                $targetResource = Get-TargetResource -Name $testPresentParams.Name -Path $testPresentParams.Path
+                
+                $targetResource.ProtectedFromAccidentalDeletion | Should Be 'No'
+            }
+
+            It 'Returns an empty description' {
+                Mock Assert-Module -MockWith { }
+                Mock Get-ADOrganizationalUnit -MockWith {
+                    $noDescriptionFakeAdOu = $protectedFakeAdOu.Clone();
+                    $noDescriptionFakeAdOu['Description'] = '';
+                    return [PSCustomObject] $noDescriptionFakeAdOu
+                }
+
+                $targetResource = Get-TargetResource -Name $testPresentParams.Name -Path $testPresentParams.Path
+
+                $targetResource.Description | Should BeNullOrEmpty
+            }
+
+        } #end context Validate Get-TargetResource method
+        
+        Context "Validate Test-TargetResource method" {
+
+            It 'Returns a "System.Boolean" type' {
+                Mock Assert-Module -MockWith { }
+                Mock Get-ADOrganizationalUnit { return [PSCustomObject] $protectedFakeAdOu }
+                $targetResource = Test-TargetResource @testPresentParams
+                
+                $targetResource -is [System.Boolean] | Should Be $true
+            }
+
+            It 'Fails when OU does not exist and "Ensure" = "Present"' {
+                Mock Assert-Module -MockWith { }
+                Mock Get-ADOrganizationalUnit -MockWith { }
+                
+                Test-TargetResource @testPresentParams | Should Be $false
+            }
+
+            It 'Fails when OU does exist but "Description" is incorrect' {
+                Mock Assert-Module -MockWith { }
+                Mock Get-ADOrganizationalUnit { return [PSCustomObject] $protectedFakeAdOu }
+                $testDescriptionParams = $testPresentParams.Clone()
+                $testDescriptionParams['Description'] = 'Wrong description'
+                
+                Test-TargetResource @testDescriptionParams | Should Be $false
+            }
+
+            It 'Fails when OU does exist but "ProtectedFromAccidentalDeletion" is incorrect' {
+                Mock Assert-Module -MockWith { }
+                Mock Get-ADOrganizationalUnit { return [PSCustomObject] $protectedFakeAdOu }
+                $testProtectedFromAccidentalDeletionParams = $testPresentParams.Clone()
+                $testProtectedFromAccidentalDeletionParams['ProtectedFromAccidentalDeletion'] = 'No'
+                
+                Test-TargetResource @testProtectedFromAccidentalDeletionParams | Should Be $false
+            }
+
+            It 'Passes when OU does exist, "Ensure" = "Present" and all properties are correct' {
+                Mock Assert-Module -MockWith { }
+                Mock Get-ADOrganizationalUnit -MockWith { return [PSCustomObject] $protectedFakeAdOu }
+                
+                Test-TargetResource @testPresentParams | Should Be $true
+            }
+
+            It 'Passes when OU does not exist and "Ensure" = "Absent"' {
+                Mock Assert-Module -MockWith { }
+                Mock Get-ADOrganizationalUnit -MockWith { }
+                
+                Test-TargetResource @testAbsentParams | Should Be $true
+            }
+
+            It 'Passes when no OU description is supplied' {
+                Mock Assert-Module -MockWith { }
+                Mock Get-ADOrganizationalUnit { return [PSCustomObject] $protectedFakeAdOu }
+                $testEmptyDescriptionParams = $testPresentParams.Clone()
+                $testEmptyDescriptionParams['Description'] = ''
+                
+                Test-TargetResource @testEmptyDescriptionParams | Should Be $true
+            }
+
+        } #end Context Validate Test-TargetResource method
+        
+        Context "Validate Set-TargetResource method" {
+
+            It 'Calls "New-ADOrganizationalUnit" when "Ensure" = "Present" and OU does not exist' {
+                Mock Assert-Module -MockWith { }
+                Mock Get-ADOrganizationalUnit -MockWith { }
+                Mock New-ADOrganizationalUnit -ParameterFilter { $Name -eq $testPresentParams.Name } -MockWith { }
+                
+                Set-TargetResource @testPresentParams
+                Assert-MockCalled New-ADOrganizationalUnit -ParameterFilter { $Name -eq $testPresentParams.Name } -Scope It
+            }
+
+            It 'Calls "Set-ADOrganizationalUnit" when "Ensure" = "Present" and OU does exist' {
+                Mock Assert-Module -MockWith { }
+                Mock Get-ADOrganizationalUnit -MockWith { return [PSCustomObject] $protectedFakeAdOu }
+                Mock Set-ADOrganizationalUnit -MockWith { }
+                
+                Set-TargetResource @testPresentParams
+                Assert-MockCalled Set-ADOrganizationalUnit -Scope It
+            }
+
+            It 'Calls "Remove-ADOrganizationalUnit" when "Ensure" = "Absent" and OU does exist but is unprotected' {
+                Mock Assert-Module -MockWith { }
+                Mock Get-ADOrganizationalUnit -MockWith {
+                    $unprotectedFakeAdOu = $protectedFakeAdOu.Clone()
+                    $unprotectedFakeAdOu['ProtectedFromAccidentalDeletion'] = $false
+                    return [PSCustomObject] $unprotectedFakeAdOu
+                }
+                Mock Remove-ADOrganizationalUnit -MockWith { }
+                
+                Set-TargetResource @testAbsentParams
+                Assert-MockCalled Remove-ADOrganizationalUnit -Scope It
+            }
+
+            It 'Calls "Remove-ADOrganizationalUnit" when "Ensure" = "Absent" and OU does exist and is protected' {
+                Mock Assert-Module -MockWith { }
+                Mock Get-ADOrganizationalUnit -MockWith { return [PSCustomObject] $protectedFakeAdOu }
+                Mock Remove-ADOrganizationalUnit -MockWith { }
+                
+                Set-TargetResource @testAbsentParams
+                Assert-MockCalled Remove-ADOrganizationalUnit -Scope It
+            }
+
+            It 'Calls "Set-ADOrganizationalUnit" when "Ensure" = "Absent", OU does exist but is protected' {
+                Mock Assert-Module -MockWith { }
+                Mock Get-ADOrganizationalUnit -MockWith { return [PSCustomObject] $protectedFakeAdOu }
+                Mock Remove-ADOrganizationalUnit -MockWith { }
+                Mock Set-ADOrganizationalUnit -MockWith { }
+                
+                Set-TargetResource @testAbsentParams
+                Assert-MockCalled Set-ADOrganizationalUnit -Scope It
+            }
+
+            It 'Does not call "Set-ADOrganizationalUnit" when "Ensure" = "Absent", OU does exist but is unprotected' {
+                Mock Assert-Module -MockWith { }
+                Mock Get-ADOrganizationalUnit -MockWith {
+                    $unprotectedFakeAdOu = $protectedFakeAdOu.Clone()
+                    $unprotectedFakeAdOu['ProtectedFromAccidentalDeletion'] = $false
+                    return [PSCustomObject] $unprotectedFakeAdOu
+                }
+                Mock Remove-ADOrganizationalUnit -MockWith { }
+                Mock Set-ADOrganizationalUnit -MockWith { }
+                
+                Set-TargetResource @testAbsentParams
+                Assert-MockCalled Set-ADOrganizationalUnit -Scope It -Exactly 0
+            }
+
+        } #end context Validate Set-TargetResource method
+    
+    } #end InModuleScope
+}


### PR DESCRIPTION
* Fixes #8 by adding the xADOrganizationalUnit functionality from the PS Gallery
* Adds unit test coverage
* Updated readme with xADOrganizationalUnit details
 * Added reference to xADGroup in the unreleased section as this was missing!

The only query I have is around the 'ProtectedFromAccidentalDeletion' parameter.
* This is implemented as a [string] { Yes | No }.
* I have left it as a string for backwards compatibility (would still require a configuration update due to the change in resource name).
* If we are going to change this to a [boolean] now is the best time to do it?!