### PR TITLE
NewDomainNetbiosName is not a param for Install-ADDSForest

### DIFF
--- a/DSCResources/MSFT_xADDomain/MSFT_xADDomain.psm1
+++ b/DSCResources/MSFT_xADDomain/MSFT_xADDomain.psm1
@@ -131,7 +131,7 @@ function Set-TargetResource
         }
         if ($DomainNetbiosName.length -gt 0)
         {
-            $params.Add("NewDomainNetbiosName", $DomainNetbiosName)
+            $params.Add("DomainNetbiosName", $DomainNetbiosName)
         }
         if ($DnsDelegationCredential -ne $null)
         {
@@ -169,7 +169,7 @@ function Set-TargetResource
         }
         if ($DomainNetbiosName.length -gt 0)
         {
-            $params.Add("NewDomainNetbiosName", $DomainNetbiosName)
+            $params.Add("DomainNetbiosName", $DomainNetbiosName)
         }
         if ($DnsDelegationCredential -ne $null)
         {


### PR DESCRIPTION
NewDomainNetbiosName is not a param for Install-ADDSForest. This incorrect param causes the resource to error. When changed to DomainNetbiosName it works fine.