### PR TITLE
xADDomainController - correct two errors in verbose logs

### DIFF
--- a/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
+++ b/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
@@ -35,7 +35,7 @@ function Get-TargetResource
         $domain = Get-ADDomain -Identity $DomainName -Credential $DomainAdministratorCredential
         if ($domain -ne $null)
         {
-            Write-Verbose -Message "Domain '$($fullDomainName)' is present. Looking for DCs ..."
+            Write-Verbose -Message "Domain '$($DomainName)' is present. Looking for DCs ..."
             try
             {
                 $dc = Get-ADDomainController -Identity $env:COMPUTERNAME -Credential $DomainAdministratorCredential

--- a/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
+++ b/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
@@ -155,7 +155,7 @@ function Test-TargetResource
     catch
     {
         if ($error[0]) {Write-Verbose $error[0].Exception}
-        Write-Verbose -Message "Domain '$($Name)' is NOT present on the current node."
+        Write-Verbose -Message "Domain '$($DomainName)' is NOT present on the current node."
         $false
     }
 }

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ The xADOrganizational Unit DSC resource will manage OUs within Active Directory.
 ### Unreleased
 
 * xWaitForADDomain: Updated to make it compatible with systems that don't have the ActiveDirectory module installed, and to allow it to function with domains/forests that don't have a domain controller with Active Directory Web Services running.
+* xADDomainController: Customer identified two cases of incorrect variables being called in Verbose output messages.  Corrected.
 
 ### 2.9.0.0
 


### PR DESCRIPTION
Customer reported two cases where verbose log output was calling incorrect variables

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xactivedirectory/68)
<!-- Reviewable:end -->
