### PR TITLE
supressed PSSA credential rule in example file

### DIFF
--- a/DSCResources/MSFT_xADUser/MSFT_xADUser.psm1
+++ b/DSCResources/MSFT_xADUser/MSFT_xADUser.psm1
@@ -71,7 +71,7 @@ $adPropertyMap = @(
 function Get-TargetResource
 {
     [OutputType([System.Collections.Hashtable])]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUserNameAndPassWordParams')]
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUserNameAndPassWordParams', '')]
     param
     (
         ## Only used if password is managed.
@@ -289,7 +289,7 @@ function Get-TargetResource
 function Test-TargetResource
 {
     [OutputType([System.Boolean])]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUserNameAndPassWordParams')]
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUserNameAndPassWordParams', '')]
     param
     (
         ## Only used if password is managed.
@@ -493,7 +493,7 @@ function Test-TargetResource
 
 function Set-TargetResource
 {
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUserNameAndPassWordParams')]
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUserNameAndPassWordParams', '')]
     param
     (
         ## Only used if password is managed.

--- a/DSCResources/MSFT_xADUser/MSFT_xADUser.psm1
+++ b/DSCResources/MSFT_xADUser/MSFT_xADUser.psm1
@@ -71,6 +71,7 @@ $adPropertyMap = @(
 function Get-TargetResource
 {
     [OutputType([System.Collections.Hashtable])]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUserNameAndPassWordParams')]
     param
     (
         ## Only used if password is managed.
@@ -288,6 +289,7 @@ function Get-TargetResource
 function Test-TargetResource
 {
     [OutputType([System.Boolean])]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUserNameAndPassWordParams')]
     param
     (
         ## Only used if password is managed.
@@ -491,6 +493,7 @@ function Test-TargetResource
 
 function Set-TargetResource
 {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUserNameAndPassWordParams')]
     param
     (
         ## Only used if password is managed.


### PR DESCRIPTION
Fixing Script Analyzer errors - in this case the password is already passed as a credential object so it shouldn't pose a security risk and to change it could break other code - thus, I'm just by-passing the rule for these 3 instances.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xactivedirectory/85)
<!-- Reviewable:end -->