### PR TITLE
Correct Verbose messages in xADDomainController - Fixes #67

### DIFF
--- a/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
+++ b/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
@@ -35,7 +35,7 @@ function Get-TargetResource
         $domain = Get-ADDomain -Identity $DomainName -Credential $DomainAdministratorCredential
         if ($domain -ne $null)
         {
-            Write-Verbose -Message "Domain '$($fullDomainName)' is present. Looking for DCs ..."
+            Write-Verbose -Message "Domain '$($DomainName)' is present. Looking for DCs ..."
             try
             {
                 $dc = Get-ADDomainController -Identity $env:COMPUTERNAME -Credential $DomainAdministratorCredential
@@ -155,7 +155,7 @@ function Test-TargetResource
     catch
     {
         if ($error[0]) {Write-Verbose $error[0].Exception}
-        Write-Verbose -Message "Domain '$($Name)' is NOT present on the current node."
+        Write-Verbose -Message "Domain '$($DomainName)' is NOT present on the current node."
         $false
     }
 }

--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ The xADDomainDefaultPasswordPolicy DSC resource will manage an Active Directory 
 ## Versions
 
 ### Unreleased
+* xADDomainController: Customer identified two cases of incorrect variables being called in Verbose output messages.  Corrected.
 
 ### 2.11.0.0
 * xWaitForADDomain: Made explicit credentials optional and other various updates


### PR DESCRIPTION
* xADDomainController: Customer identified two cases of incorrect variables being called in Verbose output messages.  Corrected.

Note: This is a reissue of https://github.com/PowerShell/xActiveDirectory/pull/68

The code was written by @mgreenegit - I just copied/pasted and ran the pester tests :+1: I did no real work.

Also, I thought we were getting rid of the link to DSCResource.Tests from the repo?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xactivedirectory/95)
<!-- Reviewable:end -->
