### PR TITLE
Handle FaultException race condition during domain creation & reboots. Fixes #73

### DIFF
--- a/DSCResources/MSFT_xADDomain/MSFT_xADDomain.psm1
+++ b/DSCResources/MSFT_xADDomain/MSFT_xADDomain.psm1
@@ -3,23 +3,35 @@ data localizedData
 {
     # culture="en-US"
     ConvertFrom-StringData @'
-        RoleNotFoundError              = Please ensure that the PowerShell module for role '{0}' is installed.
-        InvalidDomainError             = Computer is a member of the wrong domain?!
-        ExistingDomainMemberError      = Computer is already a domain member. Cannot create a new '{0}' domain?
-        InvalidCredentialError         = Domain '{0}' is available, but invalid credentials were supplied.
-        
-        QueryDomainWithLocalCredential = Computer is a domain member; querying domain '{0}' using local credential ...
-        QueryDomainWithCredential      = Computer is a workgroup member; querying for domain '{0}' using supplied credential ...
-        DomainFound                    = Active Directory domain '{0}' found.
-        DomainNotFound                 = Active Directory domain '{0}' cannot be found.
-        CreatingChildDomain            = Creating domain '{0}' as a child of domain '{1}' ...
-        CreatedChildDomain             = Child domain '{0}' created.
-        CreatingForest                 = Creating AD forest '{0}' ...
-        CreatedForest                  = AD forest '{0}' created.
-        ResourcePropertyValueIncorrect = Property '{0}' value is incorrect; expected '{1}', actual '{2}'.
-        ResourceInDesiredState         = Resource '{0}' is in the desired state.
-        ResourceNotInDesiredState      = Resource '{0}' is NOT in the desired state.
+        RoleNotFoundError                    = Please ensure that the PowerShell module for role '{0}' is installed.
+        InvalidDomainError                   = Computer is a member of the wrong domain?!
+        ExistingDomainMemberError            = Computer is already a domain member. Cannot create a new '{0}' domain?
+        InvalidCredentialError               = Domain '{0}' is available, but invalid credentials were supplied.
+        							         
+        QueryDomainWithLocalCredential       = Computer is a domain member; querying domain '{0}' using local credential ...
+        QueryDomainWithCredential            = Computer is a workgroup member; querying for domain '{0}' using supplied credential ...
+        DomainFound                          = Active Directory domain '{0}' found.
+        DomainNotFound                       = Active Directory domain '{0}' cannot be found.
+        CreatingChildDomain                  = Creating domain '{0}' as a child of domain '{1}' ...
+        CreatedChildDomain                   = Child domain '{0}' created.
+        CreatingForest                       = Creating AD forest '{0}' ...
+        CreatedForest                        = AD forest '{0}' created.
+        ResourcePropertyValueIncorrect       = Property '{0}' value is incorrect; expected '{1}', actual '{2}'.
+        ResourceInDesiredState               = Resource '{0}' is in the desired state.
+        ResourceNotInDesiredState            = Resource '{0}' is NOT in the desired state.
+        RetryingGetADDomain                  = Attempt {0} of {1} to call Get-ADDomain failed, retrying in {2} seconds.
+	UnhandledError                       = Unhandled error occured, detail here: {0}
+	FaultExceptionAndDomainShouldExist = ServiceModel FaultException detected and domain should exist, performing retry...
+
 '@
+}
+
+function Get-TrackingFilename {
+param(
+	[Parameter(Mandatory)]
+    [String] $DomainName
+	)
+	Join-Path $Env:TEMP ('{0}.xADDomain.completed' -f $DomainName)
 }
 
 function Get-TargetResource
@@ -59,51 +71,74 @@ function Get-TargetResource
     $domainFQDN = Resolve-DomainFQDN -DomainName $DomainName -ParentDomainName $ParentDomainName;
     $isDomainMember = Test-DomainMember;
 
-    try
-    {
-        if ($isDomainMember) {
-            ## We're already a domain member, so take the credentials out of the equation
-            Write-Verbose ($localizedData.QueryDomainADWithLocalCredentials -f $domainFQDN);
-            $domain = Get-ADDomain -Identity $domainFQDN -ErrorAction Stop;
-        }
-        else {
-            Write-Verbose ($localizedData.QueryDomainWithCredential -f $domainFQDN);
-            $domain = Get-ADDomain -Identity $domainFQDN -Credential $DomainAdministratorCredential -ErrorAction Stop;
-        }
+    $retries = 0
+    $maxRetries = 5
+    $retryIntervalInSeconds = 30
+    $domainShouldExist = (Test-Path (Get-TrackingFilename -DomainName $DomainName))
+    do {			
+	try
+	{
+		if ($isDomainMember) {
+			## We're already a domain member, so take the credentials out of the equation
+			Write-Verbose ($localizedData.QueryDomainADWithLocalCredentials -f $domainFQDN);
+			$domain = Get-ADDomain -Identity $domainFQDN -ErrorAction Stop;
+		}
+		else {
+			Write-Verbose ($localizedData.QueryDomainWithCredential -f $domainFQDN);
+			$domain = Get-ADDomain -Identity $domainFQDN -Credential $DomainAdministratorCredential -ErrorAction Stop;
+		}
 
-        ## No need to check whether the node is actually a domain controller. If we don't throw an exception,
-        ## the domain is already UP - and this resource shouldn't run. Domain controller functionality
-        ## should be checked by the xADDomainController resource?
-        Write-Verbose ($localizedData.DomainFound -f $domain.DnsRoot);
+		## No need to check whether the node is actually a domain controller. If we don't throw an exception,
+		## the domain is already UP - and this resource shouldn't run. Domain controller functionality
+		## should be checked by the xADDomainController resource?
+		Write-Verbose ($localizedData.DomainFound -f $domain.DnsRoot);
         
-        $targetResource = @{
-            DomainName = $domain.DnsRoot;
-            ParentDomainName = $domain.ParentDomain;
-            DomainNetBIOSName = $domain.NetBIOSName;
-        }
+		$targetResource = @{
+			DomainName = $domain.DnsRoot;
+			ParentDomainName = $domain.ParentDomain;
+			DomainNetBIOSName = $domain.NetBIOSName;
+		}
         
-        return $targetResource;
-    }
-    catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException]
-    {
-        $errorMessage = $localizedData.ExistingDomainMemberError -f $DomainName;
-        ThrowInvalidOperationError -ErrorId 'xADDomain_DomainMember' -ErrorMessage $errorMessage;
-    }
-    catch [Microsoft.ActiveDirectory.Management.ADServerDownException]
-    {
-        Write-Verbose ($localizedData.DomainNotFound -f $domainFQDN)
-        $domain = @{ };
-    }
-    catch [System.Security.Authentication.AuthenticationException]
-    {
-        $errorMessage = $localizedData.InvalidCredentialError -f $DomainName;
-        ThrowInvalidOperationError -ErrorId 'xADDomain_InvalidCredential' -ErrorMessage $errorMessage;
-    }
-    catch
-    {
-        ## Not sure what's gone on here!
-        throw $_
-    }
+		return $targetResource;
+	}
+	catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException]
+	{
+		$errorMessage = $localizedData.ExistingDomainMemberError -f $DomainName;
+		ThrowInvalidOperationError -ErrorId 'xADDomain_DomainMember' -ErrorMessage $errorMessage;
+	}
+	catch [Microsoft.ActiveDirectory.Management.ADServerDownException]
+	{
+		Write-Verbose ($localizedData.DomainNotFound -f $domainFQDN)
+		$domain = @{ };
+		# will fall into retry mechanism
+	}
+	catch [System.Security.Authentication.AuthenticationException]
+	{
+		$errorMessage = $localizedData.InvalidCredentialError -f $DomainName;
+		ThrowInvalidOperationError -ErrorId 'xADDomain_InvalidCredential' -ErrorMessage $errorMessage;
+	}
+	catch
+	{
+		$errorMessage = $localizedData.UnhandledError -f ($_.Exception | Format-List -Force | Out-String)
+		Write-Verbose $errorMessage
+
+		if ($domainShouldExist -and ($_.Exception.InnerException -is [System.ServiceModel.FaultException]))
+		{
+			Write-Verbose $localizedData.FaultExceptionAndDomainShouldExist
+			# will fall into retry mechanism
+		} else {
+			## Not sure what's gone on here!
+			throw $_
+		}
+	}
+
+	if($domainShouldExist) {
+		$retries++
+		Write-Verbose ($localizedData.RetryingGetADDomain -f $retries, $maxRetries, $retryIntervalInSeconds)
+		Sleep -Seconds ($retries * $retryIntervalInSeconds)
+	}
+
+    } while ($domainShouldExist -and ($retries -le $maxRetries) )
 
 } #end function Get-TargetResource
 
@@ -265,8 +300,10 @@ function Set-TargetResource
             $installADDSParams['DomainNetbiosName'] = $DomainNetBIOSName;
         }
         Install-ADDSForest @installADDSParams;
-        Write-Verbose -Message ($localizedData.CreatedForest); 
+        Write-Verbose -Message ($localizedData.CreatedForest -f $DomainName); 
     }  
+
+	"Finished" | Out-File -FilePath (Get-TrackingFilename -DomainName $DomainName) -Force
 
     # Signal to the LCM to reboot the node to compensate for the one we
     # suppressed from Install-ADDSForest/Install-ADDSDomain

--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ The xADComputer DSC resource will manage computer accounts within Active Directo
 ### Unreleased
 * xADDomainController: Customer identified two cases of incorrect variables being called in Verbose output messages. Corrected.
 * xADComputer: New resource added.
+* xADDomain: Added retry logic to prevent FaultException to crash in Get-TargetResource on subsequent reboots after a domain is created because the service is not yet running. This error is mostly occur when the resource is used with the DSCExtension on Azure. 
 
 ### 2.11.0.0
 * xWaitForADDomain: Made explicit credentials optional and other various updates

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ The xADComputer DSC resource will manage computer accounts within Active Directo
 ### Unreleased
 * xADDomainController: Customer identified two cases of incorrect variables being called in Verbose output messages. Corrected.
 * xADComputer: New resource added.
-* xADDomain: Added retry logic to prevent FaultException to crash in Get-TargetResource on subsequent reboots after a domain is created because the service is not yet running. This error is mostly occur when the resource is used with the DSCExtension on Azure. 
+* xADDomain: Added retry logic to prevent FaultException to crash in Get-TargetResource on subsequent reboots after a domain is created because the service is not yet running. This error mostly occur when the resource is used with the DSCExtension on Azure. 
 
 ### 2.11.0.0
 * xWaitForADDomain: Made explicit credentials optional and other various updates


### PR DESCRIPTION
As discussed in the issue.

Added a mechanism to handle race condition after reboots when creating domains using the DSCExtension on Azure. 

Occurring exception is System.ServiceModel.FaultException because the domain service is not yet ready to answer calls when the query is performed to check if domain already exist.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xactivedirectory/101)

<!-- Reviewable:end -->
