### PR TITLE
Fix missing Ensure field/read in MOF definition of xADDomainControler

### DIFF
--- a/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.schema.mof
+++ b/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.schema.mof
@@ -7,5 +7,5 @@ class MSFT_xADDomainController : OMI_BaseResource
     [write] String DatabasePath;
     [write] String LogPath;
     [write] String SysvolPath;
-	[read] String Ensure;
+    [read] String Ensure;
 };

--- a/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.schema.mof
+++ b/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.schema.mof
@@ -7,4 +7,5 @@ class MSFT_xADDomainController : OMI_BaseResource
     [write] String DatabasePath;
     [write] String LogPath;
     [write] String SysvolPath;
+	[read] String Ensure;
 };

--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Setting an ODJ Request file path for a configuration that creates a computer acc
 ## Versions
 
 ### Unreleased
+* Fix missing Ensure filed in read mode in MOF definition of xADDomainControler
 * Converted AppVeyor.yml to pull Pester from PSGallery instead of Chocolatey
 * xADUser: Adds 'PasswordAuthentication' option when testing user passwords to support NTLM authentication with Active Directory Certificate Services deployments
 * xADUser: Adds descriptions to user properties within the schema file.


### PR DESCRIPTION
@TravisEz13, linked to #52  
If not fixed then Get-dsccompliance breaks, with error events 4097 and 4252 in operational log
Tested
Have a great day

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xactivedirectory/111)

<!-- Reviewable:end -->
