### PR TITLE
Xadgroup/feature/membersvalidation

### DIFF
--- a/DSCResources/MSFT_xADCommon/MSFT_xADCommon.ps1
+++ b/DSCResources/MSFT_xADCommon/MSFT_xADCommon.ps1
@@ -293,9 +293,9 @@ function Test-Members
         $MembersToExclude
     )
 
-    if (($Members.Count -gt 0) -and ($Members[0].Length -gt 0))
+    if ($PSBoundParameters.ContainsKey('Members'))
     {
-        if ($null -eq $Members)
+        if ($null -eq $Members -or (($Members.Count -eq 1) -and ($Members[0].Length -eq 0)))
         {
             $Members = @();
         }
@@ -317,9 +317,9 @@ function Test-Members
         }
     } #end if $Members
 
-    if (($MembersToInclude.Count -gt 0) -and ($MembersToInclude[0].Length -gt 0))
+    if ($PSBoundParameters.ContainsKey('MembersToInclude'))
     {
-        if ($null -eq $MembersToInclude)
+        if ($null -eq $MembersToInclude -or (($MembersToInclude.Count -eq 1) -and ($MembersToInclude[0].Length -eq 0)))
         {
             $MembersToInclude = @();
         }
@@ -335,10 +335,9 @@ function Test-Members
         }
     } #end if $MembersToInclude
 
-    #if ($MembersToExclude.Count -gt 0)
-    if (($MembersToExclude.Count -gt 0) -and ($MembersToExclude[0].Length -gt 0))
+    if ($PSBoundParameters.ContainsKey('MembersToExclude'))
     {
-        if ($null -eq $MembersToExclude)
+        if ($null -eq $MembersToExclude -or (($MembersToExclude.Count -eq 1) -and ($MembersToExclude[0].Length -eq 0)))
         {
             $MembersToExclude = @();
         }

--- a/DSCResources/MSFT_xADCommon/MSFT_xADCommon.ps1
+++ b/DSCResources/MSFT_xADCommon/MSFT_xADCommon.ps1
@@ -293,7 +293,7 @@ function Test-Members
         $MembersToExclude
     )
 
-    if ($PSBoundParameters.ContainsKey('Members'))
+    if (($Members.Count -gt 0) -and ($Members[0].Length -gt 0))
     {
         if ($null -eq $Members)
         {
@@ -317,7 +317,7 @@ function Test-Members
         }
     } #end if $Members
 
-    if ($PSBoundParameters.ContainsKey('MembersToInclude'))
+    if (($MembersToInclude.Count -gt 0) -and ($MembersToInclude[0].Length -gt 0))
     {
         if ($null -eq $MembersToInclude)
         {
@@ -336,7 +336,7 @@ function Test-Members
     } #end if $MembersToInclude
 
     #if ($MembersToExclude.Count -gt 0)
-    if ($PSBoundParameters.ContainsKey('MembersToExclude'))
+    if (($MembersToExclude.Count -gt 0) -and ($MembersToExclude[0].Length -gt 0))
     {
         if ($null -eq $MembersToExclude)
         {

--- a/DSCResources/MSFT_xADGroup/MSFT_xADGroup.psm1
+++ b/DSCResources/MSFT_xADGroup/MSFT_xADGroup.psm1
@@ -63,15 +63,12 @@ function Get-TargetResource
         [System.String]
         $DomainController,
 
-        [ValidateNotNullOrEmpty()]
         [System.String[]]
         $Members,
 
-        [ValidateNotNullOrEmpty()]
         [System.String[]]
         $MembersToInclude,
 
-        [ValidateNotNullOrEmpty()]
         [System.String[]]
         $MembersToExclude,
 
@@ -179,15 +176,12 @@ function Test-TargetResource
         [System.String]
         $DomainController,
 
-        [ValidateNotNullOrEmpty()]
         [System.String[]]
         $Members,
 
-        [ValidateNotNullOrEmpty()]
         [System.String[]]
         $MembersToInclude,
 
-        [ValidateNotNullOrEmpty()]
         [System.String[]]
         $MembersToExclude,
 
@@ -206,15 +200,15 @@ function Test-TargetResource
     )
     ## Validate parameters before we even attempt to retrieve anything
     $assertMemberParameters = @{};
-    if ($PSBoundParameters.ContainsKey('Members'))
+    if ($PSBoundParameters.ContainsKey('Members') -and -not [system.string]::IsNullOrEmpty($Members))
     {
         $assertMemberParameters['Members'] = $Members;
     }
-    if ($PSBoundParameters.ContainsKey('MembersToInclude'))
+    if ($PSBoundParameters.ContainsKey('MembersToInclude') -and -not [system.string]::IsNullOrEmpty($MembersToInclude))
     {
         $assertMemberParameters['MembersToInclude'] = $MembersToInclude;
     }
-    if ($PSBoundParameters.ContainsKey('MembersToExclude'))
+    if ($PSBoundParameters.ContainsKey('MembersToExclude') -and -not [system.string]::IsNullOrEmpty($MembersToExclude))
     {
         $assertMemberParameters['MembersToExclude'] = $MembersToExclude;
     }
@@ -314,15 +308,12 @@ function Set-TargetResource
         [System.String]
         $DomainController,
 
-        [ValidateNotNullOrEmpty()]
         [System.String[]]
         $Members,
 
-        [ValidateNotNullOrEmpty()]
         [System.String[]]
         $MembersToInclude,
 
-        [ValidateNotNullOrEmpty()]
         [System.String[]]
         $MembersToExclude,
 
@@ -401,7 +392,7 @@ function Set-TargetResource
             {
                 ## The fact that we're in the Set method, there is no need to validate the parameter
                 ## combination as this was performed in the Test method
-                if ($PSBoundParameters.ContainsKey('Members'))
+                if ($PSBoundParameters.ContainsKey('Members') -and -not [system.string]::IsNullOrEmpty($Members))
                 {
                     # Remove all existing first and add explicit members
                     $Members = Remove-DuplicateMembers -Members $Members;
@@ -414,13 +405,13 @@ function Set-TargetResource
                     Write-Verbose -Message ($LocalizedData.AddingGroupMembers -f $Members.Count, $GroupName);
                     Add-ADGroupMember @adGroupParams -Members $Members;
                 }
-                if ($PSBoundParameters.ContainsKey('MembersToInclude'))
+                if ($PSBoundParameters.ContainsKey('MembersToInclude') -and -not [system.string]::IsNullOrEmpty($MembersToInclude))
                 {
                     $MembersToInclude = Remove-DuplicateMembers -Members $MembersToInclude;
                     Write-Verbose -Message ($LocalizedData.AddingGroupMembers -f $MembersToInclude.Count, $GroupName);
                     Add-ADGroupMember @adGroupParams -Members $MembersToInclude;
                 }
-                if ($PSBoundParameters.ContainsKey('MembersToExclude'))
+                if ($PSBoundParameters.ContainsKey('MembersToExclude') -and -not [system.string]::IsNullOrEmpty($MembersToExclude))
                 {
                     $MembersToExclude = Remove-DuplicateMembers -Members $MembersToExclude;
                     Write-Verbose -Message ($LocalizedData.RemovingGroupMembers -f $MembersToExclude.Count, $GroupName);
@@ -477,13 +468,13 @@ function Set-TargetResource
             }
 
             ## Add the required members
-            if ($PSBoundParameters.ContainsKey('Members'))
+            if ($PSBoundParameters.ContainsKey('Members') -and -not [system.string]::IsNullOrEmpty($Members))
             {
                 $Members = Remove-DuplicateMembers -Members $Members;
                 Write-Verbose -Message ($LocalizedData.AddingGroupMembers -f $Members.Count, $GroupName);
                 Add-ADGroupMember @adGroupParams -Members $Members;
             }
-            elseif ($PSBoundParameters.ContainsKey('MembersToInclude'))
+            elseif ($PSBoundParameters.ContainsKey('MembersToInclude') -and -not [system.string]::IsNullOrEmpty($MembersToInclude))
             {
                 $MembersToInclude = Remove-DuplicateMembers -Members $MembersToInclude;
                 Write-Verbose -Message ($LocalizedData.AddingGroupMembers -f $MembersToInclude.Count, $GroupName);


### PR DESCRIPTION
Removed parameter checks for Members, MembersToInclude and MembersToExclude as per Issue #116.
All AppVeyor tests are passing after the changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xactivedirectory/117)
<!-- Reviewable:end -->
