### PR TITLE
xADDomainController return path

### DIFF
--- a/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
+++ b/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
@@ -45,8 +45,15 @@ function Get-TargetResource
                 if ($dc.Domain -eq $DomainName)
                 {
                     Write-Verbose -Message "Current node '$($dc.Name)' is already a domain controller for domain '$($dc.Domain)'."
-                    $returnValue.Ensure = $true
-                    $returnValue.SiteName = $dc.Site
+
+                    $serviceNTDS     = Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\NTDS\Parameters'
+                    $serviceNETLOGON = Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\Netlogon\Parameters'
+
+                    $returnValue.Ensure       = $true
+                    $returnValue.DatabasePath = $serviceNTDS.'DSA Working Directory'
+                    $returnValue.LogPath      = $serviceNTDS.'Database log files path'
+                    $returnValue.SysvolPath   = $serviceNETLOGON.SysVol -replace '\\sysvol$', ''
+                    $returnValue.SiteName     = $dc.Site
                 }
             }
             catch

--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ Setting an ODJ Request file path for a configuration that creates a computer acc
 
 ### Unreleased
 * xADDomainController: Adds Site option.
+* xADDomainController: Populate values for DatabasePath, LogPath and SysvolPath during Get-TargetResource.
 
 ### 2.13.0.0
 * Converted AppVeyor.yml to pull Pester from PSGallery instead of Chocolatey

--- a/Tests/Unit/MSFT_xADDomainController.Tests.ps1
+++ b/Tests/Unit/MSFT_xADDomainController.Tests.ps1
@@ -23,10 +23,13 @@ $TestEnvironment = Initialize-TestEnvironment `
 try
 {
     #region Pester Test Initialization
-    $correctSiteName = 'PresentSite'
-    $incorrectSiteName = 'IncorrectSite'
-    $correctDomainName = 'present.com'
+    $correctDomainName   = 'present.com'
     $testAdminCredential = [System.Management.Automation.PSCredential]::Empty
+    $correctDatabasePath = 'C:\Windows\NTDS'
+    $correctLogPath      = 'C:\Windows\NTDS'
+    $correctSysvolPath   = 'C:\Windows\SYSVOL'
+    $correctSiteName     = 'PresentSite'
+    $incorrectSiteName   = 'IncorrectSite'
 
     $testDefaultParams = @{
         DomainAdministratorCredential = $testAdminCredential
@@ -56,17 +59,43 @@ try
 
     #region Function Get-TargetResource
     Describe -Tag 'xADDomainController' "$($Script:DSCResourceName)\Get-TargetResource" {
+
+        Mock Get-ADDomain { return $true } @commonMockParams
+        Mock Get-ADDomainController {
+            return $stubDomainController = @{
+                Site = 'PresentSite'
+                Domain = 'present.com'
+            }
+        } @commonMockParams
+        Mock Get-ItemProperty -ParameterFilter { $Path -eq 'HKLM:\SYSTEM\CurrentControlSet\Services\NTDS\Parameters' } {
+            return @{
+                'Database log files path' = 'C:\Windows\NTDS'
+                'DSA Working Directory'   = 'C:\Windows\NTDS'
+            }
+        } @commonMockParams
+        Mock Get-ItemProperty -ParameterFilter { $Path -eq 'HKLM:\SYSTEM\CurrentControlSet\Services\Netlogon\Parameters' } {
+            return @{
+                'SysVol' = 'C:\Windows\SYSVOL\sysvol'
+            }
+        } @commonMockParams
+
+        It 'Returns current "DatabasePath"' {
+            $result = Get-TargetResource @testDefaultParams -DomainName $correctDomainName
+            $result.DatabasePath | Should Be $correctDatabasePath
+        }
+
+        It 'Returns current "LogPath"' {
+            $result = Get-TargetResource @testDefaultParams -DomainName $correctDomainName
+            $result.LogPath | Should Be $correctLogPath
+        }
+
+        It 'Returns current "SysvolPath"' {
+            $result = Get-TargetResource @testDefaultParams -DomainName $correctDomainName
+            $result.SysvolPath | Should Be $correctSysvolPath
+        }
+
         It 'Returns current "SiteName"' {
-            Mock Get-ADDomain { return $true } @commonMockParams
-            Mock Get-ADDomainController {
-                return $stubDomainController = @{
-                    Site = 'PresentSite'
-                    Domain = 'present.com'
-                }
-            } @commonMockParams
-
-            $result = Get-TargetResource @testDefaultParams -DomainName $correctDomainName -SiteName $correctSiteName
-
+            $result = Get-TargetResource @testDefaultParams -DomainName $correctDomainName
             $result.SiteName | Should Be $correctSiteName
         }
     }
@@ -98,6 +127,8 @@ try
                 Mock Get-ADDomain { return $true }
                 Mock Get-ADDomainController { return $stubDomainController }
                 Mock Test-ADReplicationSite { return $true }
+                Mock Get-ItemProperty { return @{} }
+
                 $result = Test-TargetResource @testDefaultParams -DomainName $correctDomainName -SiteName $correctSiteName
 
                 $result | Should Be $false
@@ -113,6 +144,7 @@ try
                 Mock Get-ADDomain { return $true }
                 Mock Get-ADDomainController { return $stubDomainController }
                 Mock Test-ADReplicationSite { return $true }
+                Mock Get-ItemProperty { return @{} }
 
                 $result = Test-TargetResource @testDefaultParams -DomainName $correctDomainName -SiteName $correctSiteName
 


### PR DESCRIPTION
Populate values for DatabasePath, LogPath and SysvolPath during Get-TargetResource. I'm reading them from the registry, where this paths are stored as a configuration for NTDS and Netlogon services.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xactivedirectory/122)

<!-- Reviewable:end -->
