### PR TITLE
Update MSFT_xADDomainController.psm1

### DIFF
--- a/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
+++ b/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
@@ -132,7 +132,7 @@ function Set-TargetResource
         {
             $params.Add("SysvolPath", $SysvolPath)
         }
-        if ($SiteName -ne $null)
+        if ($SiteName -ne $null -and $SiteName -ne "")
         {
             $params.Add("SiteName", $SiteName)
         }

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Setting an ODJ Request file path for a configuration that creates a computer acc
 ## Versions
 
 ### Unreleased
-
+* xAdDomainController: Update to complete fix for SiteName being required field.
 ### 2.15.0.0
 * xAdDomainController: Fixes SiteName being required field.
 


### PR DESCRIPTION
Parameter SiteName is being passed as empty string instead of $Null when not present thus passing the check on 135.  Modified line accounts for both states.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xactivedirectory/133)
<!-- Reviewable:end -->
