### PR TITLE
xAdDomainController - Adds IsGlobalCatalog parameter and fix for Ensure schema violation

### DIFF
--- a/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
+++ b/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
@@ -94,11 +94,7 @@ function Set-TargetResource
 
         [String]$SiteName,
         
-        [Bool]$IsGlobalCatalog = $true,
-    
-        [Bool]$ensure,
-    
-        [String]$NTDSSettingsObjectDN
+        [Bool]$IsGlobalCatalog = $true
     )
 
     # Debug can pause Install-ADDSDomainController, so we remove it.
@@ -201,11 +197,7 @@ function Test-TargetResource
 
         [String]$SiteName,
 
-        [Bool]$IsGlobalCatalog = $true,
-    
-        [Bool]$Ensure,
-
-        [String]$NTDSSettingsObjectDN
+        [Bool]$IsGlobalCatalog = $true
     )
 
     if ($PSBoundParameters.SiteName)

--- a/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
+++ b/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
@@ -5,7 +5,7 @@
 
 function Get-TargetResource
 {
-	[OutputType([System.Collections.Hashtable])]
+    [OutputType([System.Collections.Hashtable])]
     param
     (
         [Parameter(Mandatory)]
@@ -47,7 +47,7 @@ function Get-TargetResource
                 if ($dc.Domain -eq $DomainName)
                 {
                     Write-Verbose -Message "Current node '$($dc.Name)' is already a domain controller for domain '$($dc.Domain)'."
-                    $serviceNTDS     = Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\NTDS\Parameters'
+                    $serviceNTDS     = Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\NTDS\Parameters' 
                     $serviceNETLOGON = Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\Netlogon\Parameters'
                     $returnValue.Ensure       = $true
                     $returnValue.DatabasePath = $serviceNTDS.'DSA Working Directory'

--- a/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
+++ b/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
@@ -140,7 +140,7 @@ function Set-TargetResource
         {
             $params.Add("SysvolPath", $SysvolPath)
         }
-        if ($SiteName -ne $null  -and $SiteName -ne "")
+        if ($SiteName -ne $null)
         {
             $params.Add("SiteName", $SiteName)
         }
@@ -156,7 +156,7 @@ function Set-TargetResource
         # suppressed from Install-ADDSDomainController
         $global:DSCMachineStatus = 1
     }
-    elseif ($targetResource.Ensure -eq $true)
+    elseif ($targetResource.Ensure)
     {
         ## Node is a domain controller. We check if other properties are in desired state
         if ($PSBoundParameters["SiteName"] -and $targetResource.SiteName -ne $SiteName)
@@ -201,7 +201,7 @@ function Test-TargetResource
 
         [Bool]$IsGlobalCatalog = $true,
     
-        [Bool]$Ensure = $true,
+        [Bool]$Ensure,
 
         [String]$NTDSSettingsObjectDN
     )

--- a/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
+++ b/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
@@ -239,7 +239,7 @@ function Test-TargetResource
         }
         if ($isGCCorrect -eq $false -or $isinsite -eq $false)
         {
-            $iscomplaint = $False
+            $iscompliant = $False
         }
     }
     catch

--- a/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
+++ b/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
@@ -168,8 +168,8 @@ function Set-TargetResource
         {
             ## DC is not in the expected Global Catalog state
             Write-Verbose "Setting the Global Catalog state to '$IsGlobalCatalog'"
-            if ($IsGlobalCatalog = $true){$value = 1}
-            if ($IsGlobalCatalog = $false){$value = 0}
+            if ($IsGlobalCatalog -eq $true){$value = 1}
+            if ($IsGlobalCatalog -eq $false){$value = 0}
             Set-adobject $targetresource.NTDSSettingsObjectDN -replace @{options = $value}
         }
     }

--- a/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
+++ b/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
@@ -95,7 +95,7 @@ function Set-TargetResource
 
         [String]$SiteName,
         
-        [Bool]$IsGlobalCatalog = $true
+        [Bool]$IsGlobalCatalog = $true,
 	
 	[Bool]$ensure,
 	

--- a/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
+++ b/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
@@ -96,9 +96,9 @@ function Set-TargetResource
         
         [Bool]$IsGlobalCatalog = $true,
     
-    [Bool]$ensure,
+        [Bool]$ensure,
     
-    [String]$NTDSSettingsObjectDN
+        [String]$NTDSSettingsObjectDN
     )
 
     # Debug can pause Install-ADDSDomainController, so we remove it.
@@ -140,7 +140,7 @@ function Set-TargetResource
         {
             $params.Add("SysvolPath", $SysvolPath)
         }
-        if ($SiteName -ne $null)
+        if ($SiteName -ne $null  -and $SiteName -ne "")
         {
             $params.Add("SiteName", $SiteName)
         }
@@ -201,9 +201,9 @@ function Test-TargetResource
 
         [Bool]$IsGlobalCatalog = $true,
     
-    [Bool]$Ensure = $true,
+        [Bool]$Ensure = $true,
 
-    [String]$NTDSSettingsObjectDN
+        [String]$NTDSSettingsObjectDN
     )
 
     if ($PSBoundParameters.SiteName)

--- a/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
+++ b/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
@@ -8,7 +8,7 @@ function Get-TargetResource
     [OutputType([System.Collections.Hashtable])]
     param
     (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory)]    
         [String]$DomainName,
 
         [Parameter(Mandatory)]
@@ -95,10 +95,10 @@ function Set-TargetResource
         [String]$SiteName,
         
         [Bool]$IsGlobalCatalog = $true,
-	
-	[Bool]$ensure,
-	
-	[String]$NTDSSettingsObjectDN
+    
+    [Bool]$ensure,
+    
+    [String]$NTDSSettingsObjectDN
     )
 
     # Debug can pause Install-ADDSDomainController, so we remove it.
@@ -200,10 +200,10 @@ function Test-TargetResource
         [String]$SiteName,
 
         [Bool]$IsGlobalCatalog = $true,
-	
-	[Bool]$Ensure = $true,
+    
+    [Bool]$Ensure = $true,
 
-	[String]$NTDSSettingsObjectDN
+    [String]$NTDSSettingsObjectDN
     )
 
     if ($PSBoundParameters.SiteName)

--- a/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
+++ b/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
@@ -200,7 +200,7 @@ function Test-TargetResource
 
         [String]$SiteName,
 
-        [Bool]$IsGlobalCatalog = $true
+        [Bool]$IsGlobalCatalog = $true,
 	
 	[Bool]$Ensure = $true,
 

--- a/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
+++ b/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
@@ -230,12 +230,16 @@ function Test-TargetResource
         elseif ($existingResource.SiteName -ne $SiteName)
         {
             Write-Verbose "Domain Controller Site is not in a desired state. Expected '$SiteName', actual '$($existingResource.SiteName)'"
-            $isCompliant = $false
+            $isInSite = $false
         }
         ## Check Global Catalog Config
         if ($existingresource.isglobalcatalog -ne $IsglobalCatalog)
         {
-            $isCompliant = $false
+            $isGCCorrect = $false
+        }
+        if ($isGCCorrect -eq $false -or $isinsite -eq $false)
+        {
+            $iscomplaint = $False
         }
     }
     catch

--- a/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
+++ b/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
@@ -5,7 +5,7 @@
 
 function Get-TargetResource
 {
-    [OutputType([System.Collections.Hashtable])]
+	[OutputType([System.Collections.Hashtable])]
     param
     (
         [Parameter(Mandatory)]
@@ -169,7 +169,7 @@ function Set-TargetResource
             ## DC is not in the expected Global Catalog state
             Write-Verbose "Setting the Global Catalog state to '$IsGlobalCatalog'"
             if ($IsGlobalCatalog = $true){$value = 1}
-            if ($IsGlobalCatalog - $false){$value = 0}
+            if ($IsGlobalCatalog = $false){$value = 0}
             Set-adobject $targetresource.NTDSSettingsObjectDN -replace @{options = $value}
         }
     }

--- a/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
+++ b/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
@@ -47,7 +47,6 @@ function Get-TargetResource
                 if ($dc.Domain -eq $DomainName)
                 {
                     Write-Verbose -Message "Current node '$($dc.Name)' is already a domain controller for domain '$($dc.Domain)'."
-
                     $serviceNTDS     = Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\NTDS\Parameters'
                     $serviceNETLOGON = Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\Netlogon\Parameters'
                     $returnValue.Ensure       = $true

--- a/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
+++ b/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
@@ -50,7 +50,6 @@ function Get-TargetResource
 
                     $serviceNTDS     = Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\NTDS\Parameters'
                     $serviceNETLOGON = Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\Netlogon\Parameters'
-
                     $returnValue.Ensure       = $true
                     $returnValue.DatabasePath = $serviceNTDS.'DSA Working Directory'
                     $returnValue.LogPath      = $serviceNTDS.'Database log files path'
@@ -97,6 +96,10 @@ function Set-TargetResource
         [String]$SiteName,
         
         [Bool]$IsGlobalCatalog = $true
+	
+	[Bool]$ensure,
+	
+	[String]$NTDSSettingsObjectDN
     )
 
     # Debug can pause Install-ADDSDomainController, so we remove it.
@@ -198,6 +201,10 @@ function Test-TargetResource
         [String]$SiteName,
 
         [Bool]$IsGlobalCatalog = $true
+	
+	[Bool]$Ensure = $true,
+
+	[String]$NTDSSettingsObjectDN
     )
 
     if ($PSBoundParameters.SiteName)

--- a/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
+++ b/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
@@ -156,7 +156,7 @@ function Set-TargetResource
         # suppressed from Install-ADDSDomainController
         $global:DSCMachineStatus = 1
     }
-    elseif ($targetResource.Ensure)
+    elseif ($targetResource.Ensure -eq $true)
     {
         ## Node is a domain controller. We check if other properties are in desired state
         if ($PSBoundParameters["SiteName"] -and $targetResource.SiteName -ne $SiteName)

--- a/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
+++ b/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
@@ -158,13 +158,6 @@ function Set-TargetResource
     }
     elseif ($targetResource.Ensure)
     {
-        ## Node is a domain controller. We check if other properties are in desired state
-        if ($PSBoundParameters["SiteName"] -and $targetResource.SiteName -ne $SiteName)
-        {
-            ## DC is not in correct site. Move it.
-            Write-Verbose "Moving Domain Controller from '$($targetResource.SiteName)' to '$SiteName'"
-            Move-ADDirectoryServer -Identity $env:COMPUTERNAME -Site $SiteName -Credential $DomainAdministratorCredential
-        }
         ## Check if Node Global Catalog state is correct
         if ($targetresource.IsGlobalCatalog -ne $IsGlobalCatalog)
         {
@@ -174,6 +167,15 @@ function Set-TargetResource
             if ($IsGlobalCatalog -eq $false){$value = 0}
             Set-adobject $targetresource.NTDSSettingsObjectDN -replace @{options = $value}
         }
+        
+        ## Node is a domain controller. We check if other properties are in desired state
+        if ($PSBoundParameters["SiteName"] -and $targetResource.SiteName -ne $SiteName)
+        {
+            ## DC is not in correct site. Move it.
+            Write-Verbose "Moving Domain Controller from '$($targetResource.SiteName)' to '$SiteName'"
+            Move-ADDirectoryServer -Identity $env:COMPUTERNAME -Site $SiteName -Credential $DomainAdministratorCredential
+        }
+        
     }
 }
 

--- a/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.schema.mof
+++ b/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.schema.mof
@@ -9,6 +9,6 @@ class MSFT_xADDomainController : OMI_BaseResource
     [write] String SysvolPath;
     [write] String SiteName;
     [write] Boolean IsGlobalCatalog;
-    [write] String Ensure;
+    [write] Boolean Ensure;
     [write] String NTDSSettingsObjectDN;
 };

--- a/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.schema.mof
+++ b/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.schema.mof
@@ -8,4 +8,5 @@ class MSFT_xADDomainController : OMI_BaseResource
     [write] String LogPath;
     [write] String SysvolPath;
     [write] String SiteName;
+    [write] String IsGlobalCatalog;
 };

--- a/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.schema.mof
+++ b/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.schema.mof
@@ -9,6 +9,6 @@ class MSFT_xADDomainController : OMI_BaseResource
     [write] String SysvolPath;
     [write] String SiteName;
     [write] Boolean IsGlobalCatalog;
-    [write] Boolean Ensure;
-    [write] String NTDSSettingsObjectDN;
+    [read] Boolean Ensure;
+    [read] String NTDSSettingsObjectDN;
 };

--- a/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.schema.mof
+++ b/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.schema.mof
@@ -8,5 +8,7 @@ class MSFT_xADDomainController : OMI_BaseResource
     [write] String LogPath;
     [write] String SysvolPath;
     [write] String SiteName;
-    [write] String IsGlobalCatalog;
+    [write] Boolean IsGlobalCatalog;
+    [write] String Ensure;
+    [write] String NTDSSettingsObjectDN;
 };

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ These DSC Resources allow you to configure new domains, child domains, and high 
 * **LogPath**: Specifies the fully qualified, non-UNC path to a directory on a fixed disk of the local computer where the log file for this operation will be written (optional).
 * **SysvolPath**: Specifies the fully qualified, non-UNC path to a directory on a fixed disk of the local computer where the Sysvol file will be written. (optional)
 * **SiteName**: Specify the name of an existing site where new domain controller will be placed. (optional)
+* **IsGlobalCatalog**: Specify if the new Domain Controller will be a Global Catalog Server (Default = $True, Optional)
 
 ### **xADUser**
 
@@ -243,7 +244,8 @@ Setting an ODJ Request file path for a configuration that creates a computer acc
 ## Versions
 
 ### Unreleased
-* xAdDomainController: Updates line 135 to Fix SiteName being required field.
+* xAdDomainController: Add Option to disable or enable the global catalog
+
 ### 2.15.0.0
 * xAdDomainController: Fixes SiteName being required field.
 

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Setting an ODJ Request file path for a configuration that creates a computer acc
 ## Versions
 
 ### Unreleased
-
+* xAdDomainController: Updates line 135 to Fix SiteName being required field.
 ### 2.15.0.0
 * xAdDomainController: Fixes SiteName being required field.
 

--- a/README.md
+++ b/README.md
@@ -244,7 +244,8 @@ Setting an ODJ Request file path for a configuration that creates a computer acc
 ## Versions
 
 ### Unreleased
-* xAdDomainController: Add Option to disable or enable the global catalog
+* xAdDomainController: Add Option to disable or enable the global catalog per issue #75
+* xAdDomainController: Fix to get-dscconfiguration issue with Ensure (Reference to Pull Request #111)
 
 ### 2.15.0.0
 * xAdDomainController: Fixes SiteName being required field.


### PR DESCRIPTION
Adds Option IsGlobalCatalog to xAdDomainController per issue/feature request #75 and fixes get-dscconfiguration issue with xAdDomainController #111 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xactivedirectory/135)
<!-- Reviewable:end -->
