### PR TITLE
Removed Ensure property

### DIFF
--- a/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
+++ b/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
@@ -28,7 +28,6 @@ function Get-TargetResource
 
     $returnValue = @{
         DomainName = $DomainName
-        Ensure = $false
     }
 
     try
@@ -49,7 +48,6 @@ function Get-TargetResource
                     $serviceNTDS     = Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\NTDS\Parameters'
                     $serviceNETLOGON = Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\Netlogon\Parameters'
 
-                    $returnValue.Ensure       = $true
                     $returnValue.DatabasePath = $serviceNTDS.'DSA Working Directory'
                     $returnValue.LogPath      = $serviceNTDS.'Database log files path'
                     $returnValue.SysvolPath   = $serviceNETLOGON.SysVol -replace '\\sysvol$', ''

--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ Setting an ODJ Request file path for a configuration that creates a computer acc
 
 ### Unreleased
 
+* Removed Ensure property from xADDomainController, fixes #155.
 * Converted AppVeyor.yml to use DSCResource.tests shared code.
 * Opted-In to markdown rule validation.
 * Readme.md modified resolve markdown rule violations.


### PR DESCRIPTION
Remove unused Ensure property from Get-TargetResource.
Fixes #155

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xactivedirectory/160)
<!-- Reviewable:end -->
