### PR TITLE
BREAKING CHANGE: xADComputer:  A computer account can now be created disabled

### DIFF
--- a/DSCResources/MSFT_xADComputer/MSFT_xADComputer.schema.mof
+++ b/DSCResources/MSFT_xADComputer/MSFT_xADComputer.schema.mof
@@ -15,6 +15,7 @@ class MSFT_xADComputer : OMI_BaseResource
     [Write, Description("Specifies the user account credentials to use to perform the task"), EmbeddedInstance("MSFT_Credential")] String DomainAdministratorCredential;
     [Write, Description("Specifies the full path to the Offline Domain Join Request file to create.")] String RequestFile;
     [Write, ValueMap{"Present", "Absent"},Values{"Present", "Absent"}] String Ensure;
+    [Write, Description("Specifies if the the computer account should be created disabled ($true) or enabled ($false). Default a computer account will be created as enabled. If the parameter Enabled is used in the same configuration that will override this parameter.")] Boolean CreateDisabled;
     [Read, Description("Returns the X.500 path of the computer object")] String DistinguishedName;
     [Read, Description("Returns the security identifier of the computer object")] String SID;
 };

--- a/DSCResources/MSFT_xADComputer/en-US/MSFT_xADComputer.psd1
+++ b/DSCResources/MSFT_xADComputer/en-US/MSFT_xADComputer.psd1
@@ -12,6 +12,7 @@ ConvertFrom-StringData @'
     ADComputerNotInDesiredState       = Active Directory computer '{0}' is NOT in the desired state.
 
     AddingADComputer                  = Adding Active Directory computer '{0}'.
+    AddingADComputerAsDisabled        = Adding a disabled Active Directory computer account '{0}'.
     RemovingADComputer                = Removing Active Directory computer '{0}'.
     UpdatingADComputer                = Updating Active Directory computer '{0}'.
     UpdatingADComputerProperty        = Updating computer property '{0}' with/to '{1}'.

--- a/README.md
+++ b/README.md
@@ -250,6 +250,10 @@ The xADComputer DSC resource will manage computer accounts within Active Directo
   * It not specified, it defaults to 'Present'.
 * **DistinguishedName**: Returns the X.500 path of the computer object (read-only).
 * **SID**: Returns the security identifier of the computer object (read-only).
+* **CreateDisabled*: Specifies if the the computer account should be created disabled ($true)
+  or enabled ($false). Default a computer account will be created as enabled. If
+  the parameter Enabled is used in the same configuration then that will override this
+  parameter.
 
 Note: An ODJ Request file will only be created when a computer account is first created in the domain.
 Setting an ODJ Request file path for a configuration that creates a computer account that already exists will not cause the file to be created.
@@ -262,6 +266,16 @@ Setting an ODJ Request file path for a configuration that creates a computer acc
 * Opted-In to markdown rule validation.
 * Readme.md modified resolve markdown rule violations.
 * Added CodeCov.io support.
+* Changes to xADComputer
+  * BREAKING CHANGE: Previously a computer account was always set to enabled
+    regardless of `Enabled` parameter was used in a configuration. Now if
+    the `Enabled` parameter is left out of the configuration, the
+    computer account will not be evaluated if it enabled. So if a computer is
+    disabled, the resource will not enabled it unless `Enabled` parameter is
+    set to `$true` in the configuration.
+  * A computer account can now be created disabled by setting the parameter
+    `CreateDisabled` to `$true`. Default a computer account will be created
+    as enabled.
 
 ### 2.16.0.0
 

--- a/Tests/Unit/MSFT_xADComputer.Tests.ps1
+++ b/Tests/Unit/MSFT_xADComputer.Tests.ps1
@@ -605,6 +605,60 @@ try
                 Assert-MockCalled Remove-ADComputer -ParameterFilter { $Identity.ToString() -eq $testAbsentParams.ComputerName } -Scope It;
             }
 
+            Context 'When a computer account that should be disabled' {
+                BeforeAll {
+                    Mock -CommandName Set-ADComputer
+                    Mock -CommandName New-ADComputer
+
+                    Mock -CommandName Get-TargetResource -MockWith {
+                        return $fakeADComputer
+                    }
+                }
+
+                Context 'When specifying the parameter Enabled with the value $false' {
+                    It 'Should call Set-ADComputer to disable the computer account' {
+                        $setTargetResourceParameters = $testPresentParams.Clone()
+                        $setTargetResourceParameters['Enabled'] = $false
+
+                        Set-TargetResource @setTargetResourceParameters
+
+                        Assert-MockCalled -CommandName New-ADComputer -Scope It -Exactly -Times 0
+
+                        Assert-MockCalled -CommandName Set-ADComputer -ParameterFilter {
+                            $Enabled -eq $false
+                        } -Scope It -Exactly -Times 1
+                    }
+                }
+            }
+
+            Context 'When a computer account that should be enabled' {
+                BeforeAll {
+                    Mock -CommandName Set-ADComputer
+                    Mock -CommandName New-ADComputer
+
+                    Mock -CommandName Get-TargetResource -MockWith {
+                        $disabledFakeADComputer = $fakeADComputer.Clone()
+                        $disabledFakeADComputer['Enabled'] = $false
+                        return $disabledFakeADComputer
+                    }
+                }
+
+                Context 'When specifying the parameter Enabled with the value $true' {
+                    It 'Should call Set-ADComputer to enable the computer account' {
+                        $setTargetResourceParameters = $testPresentParams.Clone()
+                        $setTargetResourceParameters['Enabled'] = $true
+
+                        Set-TargetResource @setTargetResourceParameters
+
+                        Assert-MockCalled -CommandName New-ADComputer -Scope It -Exactly -Times 0
+
+                        Assert-MockCalled -CommandName Set-ADComputer -ParameterFilter {
+                            $Enabled -eq $true
+                        } -Scope It -Exactly -Times 1
+                    }
+                }
+            }
+
             Context 'When creating a computer account that should be enabled' {
                 BeforeAll {
                     Mock -CommandName Set-ADComputer
@@ -623,11 +677,11 @@ try
 
                         Set-TargetResource @setTargetResourceParameters
 
-                        Assert-MockCalled New-ADComputer -ParameterFilter {
+                        Assert-MockCalled -CommandName New-ADComputer -ParameterFilter {
                             $Enabled -eq $true
                         } -Scope It -Exactly -Times 1
 
-                        Assert-MockCalled Set-ADComputer -ParameterFilter {
+                        Assert-MockCalled -CommandName Set-ADComputer -ParameterFilter {
                             $Enabled -eq $true -or $Enabled -eq $false
                         } -Scope It -Exactly -Times 0
                     }
@@ -640,11 +694,11 @@ try
 
                         Set-TargetResource @setTargetResourceParameters
 
-                        Assert-MockCalled New-ADComputer -ParameterFilter {
+                        Assert-MockCalled -CommandName New-ADComputer -ParameterFilter {
                             $Enabled -eq $true
                         } -Scope It -Exactly -Times 1
 
-                        Assert-MockCalled Set-ADComputer -ParameterFilter {
+                        Assert-MockCalled -CommandName Set-ADComputer -ParameterFilter {
                             $Enabled -eq $true -or $Enabled -eq $false
                         } -Scope It -Exactly -Times 0
                     }
@@ -658,11 +712,11 @@ try
 
                         Set-TargetResource @setTargetResourceParameters
 
-                        Assert-MockCalled New-ADComputer -ParameterFilter {
+                        Assert-MockCalled -CommandName New-ADComputer -ParameterFilter {
                             $Enabled -eq $true
                         } -Scope It -Exactly -Times 1
 
-                        Assert-MockCalled Set-ADComputer -ParameterFilter {
+                        Assert-MockCalled -CommandName Set-ADComputer -ParameterFilter {
                             $Enabled -eq $true -or $Enabled -eq $false
                         } -Scope It -Exactly -Times 0
                     }
@@ -676,11 +730,11 @@ try
 
                         Set-TargetResource @setTargetResourceParameters
 
-                        Assert-MockCalled New-ADComputer -ParameterFilter {
+                        Assert-MockCalled -CommandName New-ADComputer -ParameterFilter {
                             $Enabled -eq $true
                         } -Scope It -Exactly -Times 1
 
-                        Assert-MockCalled Set-ADComputer -ParameterFilter {
+                        Assert-MockCalled -CommandName Set-ADComputer -ParameterFilter {
                             $Enabled -eq $true -or $Enabled -eq $false
                         } -Scope It -Exactly -Times 0
                     }
@@ -709,11 +763,11 @@ try
 
                         Set-TargetResource @setTargetResourceParameters
 
-                        Assert-MockCalled New-ADComputer -ParameterFilter {
+                        Assert-MockCalled -CommandName New-ADComputer -ParameterFilter {
                             $Enabled -eq $false
                         } -Scope It -Exactly -Times 1
 
-                        Assert-MockCalled Set-ADComputer -ParameterFilter {
+                        Assert-MockCalled -CommandName Set-ADComputer -ParameterFilter {
                             $Enabled -eq $true -or $Enabled -eq $false
                         } -Scope It -Exactly -Times 0
                     }
@@ -726,11 +780,11 @@ try
 
                         Set-TargetResource @setTargetResourceParameters
 
-                        Assert-MockCalled New-ADComputer -ParameterFilter {
+                        Assert-MockCalled -CommandName New-ADComputer -ParameterFilter {
                             $Enabled -eq $false
                         } -Scope It -Exactly -Times 1
 
-                        Assert-MockCalled Set-ADComputer -ParameterFilter {
+                        Assert-MockCalled -CommandName Set-ADComputer -ParameterFilter {
                             $Enabled -eq $true -or $Enabled -eq $false
                         } -Scope It -Exactly -Times 0
                     }
@@ -744,11 +798,11 @@ try
 
                         Set-TargetResource @setTargetResourceParameters
 
-                        Assert-MockCalled New-ADComputer -ParameterFilter {
+                        Assert-MockCalled -CommandName New-ADComputer -ParameterFilter {
                             $Enabled -eq $false
                         } -Scope It -Exactly -Times 1
 
-                        Assert-MockCalled Set-ADComputer -ParameterFilter {
+                        Assert-MockCalled -CommandName Set-ADComputer -ParameterFilter {
                             $Enabled -eq $true -or $Enabled -eq $false
                         } -Scope It -Exactly -Times 0
                     }
@@ -762,11 +816,11 @@ try
 
                         Set-TargetResource @setTargetResourceParameters
 
-                        Assert-MockCalled New-ADComputer -ParameterFilter {
+                        Assert-MockCalled -CommandName New-ADComputer -ParameterFilter {
                             $Enabled -eq $false
                         } -Scope It -Exactly -Times 1
 
-                        Assert-MockCalled Set-ADComputer -ParameterFilter {
+                        Assert-MockCalled -CommandName Set-ADComputer -ParameterFilter {
                             $Enabled -eq $true -or $Enabled -eq $false
                         } -Scope It -Exactly -Times 0
                     }


### PR DESCRIPTION
- BREAKING CHANGE: Previously a computer account was always set to enabled
  regardless of `Enabled` parameter was used in a configuration. Now if
  the `Enabled` parameter is left out of the configuration, the
  computer account will not be evaluated if it enabled. So if a computer is
  disabled, the resource will not enabled it unless `Enabled` parameter is
  set to `$true` in the configuration.
 - A computer account can now be created disabled by setting the parameter
  `CreateDisabled` to `$true`. Default a computer account will be created
  as enabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xactivedirectory/168)
<!-- Reviewable:end -->
