### PR TITLE
Add xADReplicationSite resource.

### DIFF
--- a/DSCResources/MSFT_xADReplicationSite/MSFT_xADReplicationSite.psm1
+++ b/DSCResources/MSFT_xADReplicationSite/MSFT_xADReplicationSite.psm1
@@ -1,0 +1,146 @@
+<#
+    .SYNOPSIS
+        Returns the current state of the AD replication site.
+
+    .PARAMETER Name
+        Specifies the name of the AD replication site.
+#>
+function Get-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Name
+    )
+
+    # Get the replication site filtered by it's name. If the site is not
+    # present, the command will return $null.
+    $replicationSite = Get-ADReplicationSite -Filter { Name -eq $Name }
+
+    if ($null -eq $replicationSite)
+    {
+        $returnValue = @{
+            Ensure                     = 'Absent'
+            Name                       = $Name
+            RenameDefaultFirstSiteName = ''
+        }
+    }
+    else
+    {
+        $returnValue = @{
+            Ensure                     = 'Present'
+            Name                       = $Name
+            RenameDefaultFirstSiteName = ''
+        }
+    }
+
+    return $returnValue
+}
+
+<#
+    .SYNOPSIS
+        Add, remove or rename the AD replication site.
+
+    .PARAMETER Ensure
+        Specifies if the AD replication site should be added or remove. Default
+        value is 'Present'.
+
+    .PARAMETER Name
+        Specifies the name of the AD replication site.
+
+    .PARAMETER RenameDefaultFirstSiteName
+        Specify if the Default-First-Site-Name should be renamed, if it exists.
+        Dafult value is 'false'.
+#>
+function Set-TargetResource
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter()]
+        [ValidateSet('Present', 'Absent')]
+        [System.String]
+        $Ensure = 'Present',
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Name,
+
+        [Parameter()]
+        [System.Boolean]
+        $RenameDefaultFirstSiteName = $false
+    )
+
+    if ($Ensure -eq 'Present')
+    {
+        $defaultFirstSiteName = Get-ADReplicationSite -Filter { Name -eq 'Default-First-Site-Name' }
+
+        <#
+            Check if the user specified to rename the Default-First-Site-Name
+            and if it still exists. If both is true, rename the replication site
+            instead of creating a new site.
+        #>
+        if ($RenameDefaultFirstSiteName -and ($null -ne $defaultFirstSiteName))
+        {
+            Write-Verbose "Add the replication site 'Default-First-Site-Name' to '$Name'"
+
+            Rename-ADObject -Identity $defaultFirstSiteName.DistinguishedName -NewName $Name -ErrorAction Stop
+        }
+        else
+        {
+            Write-Verbose "Add the replication site '$Name'"
+
+            New-ADReplicationSite -Name $Name -ErrorAction Stop
+        }
+    }
+
+    if ($Ensure -eq 'Absent')
+    {
+        Write-Verbose "Remove the replication site '$Name'"
+
+        Remove-ADReplicationSite -Identity $Name -Confirm:$false -ErrorAction Stop
+    }
+}
+
+<#
+    .SYNOPSIS
+        Test the AD replication site.
+
+    .PARAMETER Ensure
+        Specifies if the AD replication site should be added or remove. Default
+        value is 'Present'.
+
+    .PARAMETER Name
+        Specifies the name of the AD replication site.
+
+    .PARAMETER RenameDefaultFirstSiteName
+        Specify if the Default-First-Site-Name should be renamed, if it exists.
+        Dafult value is 'false'.
+#>
+function Test-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param
+    (
+        [Parameter()]
+        [ValidateSet('Present', 'Absent')]
+        [System.String]
+        $Ensure = 'Present',
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Name,
+
+        [Parameter()]
+        [System.Boolean]
+        $RenameDefaultFirstSiteName = $false
+    )
+
+    $currentConfiguration = Get-TargetResource -Name $Name
+
+    return $currentConfiguration.Ensure -eq $Ensure
+}

--- a/DSCResources/MSFT_xADReplicationSite/MSFT_xADReplicationSite.schema.mof
+++ b/DSCResources/MSFT_xADReplicationSite/MSFT_xADReplicationSite.schema.mof
@@ -1,0 +1,7 @@
+[ClassVersion("1.0.0.0"), FriendlyName("xADReplicationSite")]
+class MSFT_xADReplicationSite : OMI_BaseResource
+{
+    [Write, Description("Specifies if the AD replication site should be added or remove. Default value is 'Present'. { *Present* | Absent }."), ValueMap{"Present", "Absent"}, Values{"Present", "Absent"}] String Ensure;
+    [Key, Description("Specifies the name of the AD replication site.")] String Name;
+    [Write, Description("Specify if the Default-First-Site-Name should be renamed, if it exists. Dafult value is 'false'.")] Boolean RenameDefaultFirstSiteName;
+};

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Please check out common DSC Resource [contributing guidelines](https://github.co
 
 ## Description
 
-The **xActiveDirectory** module contains the **xADComputer, xADDomain, xADDomainController, xADUser, xWaitForDomain, xADDomainTrust, xADRecycleBin, xADGroup, xADOrganizationalUnit and xADDomainDefaultPasswordPolicy** DSC Resources.
+The **xActiveDirectory** module contains the **xADComputer, xADDomain, xADDomainController, xADUser, xWaitForDomain, xADDomainTrust, xADRecycleBin, xADGroup, xADOrganizationalUnit, xADReplicationSite and xADDomainDefaultPasswordPolicy** DSC Resources.
 These DSC Resources allow you to configure new domains, child domains, and high availability domain controllers, establish cross-domain trusts and manage users, groups and OUs.
 
 ## Resources
@@ -27,6 +27,7 @@ These DSC Resources allow you to configure new domains, child domains, and high 
 * **xADDomainTrust** establishes cross-domain trusts.
 * **xADGroup** modifies and removes Active Directory groups.
 * **xADOrganizationalUnit** creates and deletes Active Directory OUs.
+* **xADReplicationSite** creates and deletes Active Directory replication sites.
 * **xADUser** modifies and removes Active Directory Users.
 * **xADServicePrincipalName** adds or removes the SPN to a user or computer account.
 * **xWaitForDomain** waits for new, remote domain to setup.
@@ -60,6 +61,12 @@ These DSC Resources allow you to configure new domains, child domains, and high 
 * **LogPath**: Specifies the fully qualified, non-UNC path to a directory on a fixed disk of the local computer where the log file for this operation will be written (optional).
 * **SysvolPath**: Specifies the fully qualified, non-UNC path to a directory on a fixed disk of the local computer where the Sysvol file will be written. (optional)
 * **SiteName**: Specify the name of an existing site where new domain controller will be placed. (optional)
+
+### **xADReplicationSite**
+
+* **Ensure**: Specifies if the AD replication site should be added or remove. Default value is 'Present'. { *Present* | Absent }.
+* **Name**: Specifies the name of the AD replication site.
+* **RenameDefaultFirstSiteName**: Specify if the Default-First-Site-Name should be renamed, if it exists. Dafult value is 'false'.
 
 ### **xADUser**
 
@@ -266,6 +273,8 @@ Setting an ODJ Request file path for a configuration that creates a computer acc
 ## Versions
 
 ### Unreleased
+
+* xADReplicationSite: Resource added.
 
 ### 2.17.0.0
 
@@ -1007,6 +1016,83 @@ Param(
 Example_xADGroup -GroupName 'TestGroup' -Scope 'DomainLocal' -Description 'Example test domain local security group' -ConfigurationData $ConfigurationData
 
 Start-DscConfiguration -Path .\Example_xADGroup -Wait -Verbose
+```
+
+### Create an Active Directory Replication Site
+
+In this example, we will create an Active Directory replication site called
+'Seattle'.
+
+```powershell
+configuration Example_xADReplicationSite
+{
+    Import-DscResource -Module xActiveDirectory
+
+    Node $AllNodes.NodeName
+    {
+        xADReplicationSite 'SeattleSite'
+        {
+           Ensure = 'Present'
+           Name   = 'Seattle'
+        }
+    }
+}
+
+Example_xADReplicationSite
+
+Start-DscConfiguration -Path .\Example_xADReplicationSite -Wait -Verbose
+```
+
+### Create an Active Directory Replication Site (Rename Default-First-Site-Name)
+
+In this example, we will create an Active Directory replication site called
+'Seattle'. If the 'Default-First-Site-Name' site exists, it will rename this
+site instead of create a new one.
+
+```powershell
+configuration Example_xADReplicationSite
+{
+    Import-DscResource -Module xActiveDirectory
+
+    Node $AllNodes.NodeName
+    {
+        xADReplicationSite 'SeattleSite'
+        {
+           Ensure                     = 'Present'
+           Name                       = 'Seattle'
+           RenameDefaultFirstSiteName = $true
+        }
+    }
+}
+
+Example_xADReplicationSite
+
+Start-DscConfiguration -Path .\Example_xADReplicationSite -Wait -Verbose
+```
+
+### Remove an Active Directory Replication Site
+
+In this example, we will remove the Active Directory replication site called
+'Cupertino'.
+
+```powershell
+configuration Example_xADReplicationSite
+{
+    Import-DscResource -Module xActiveDirectory
+
+    Node $AllNodes.NodeName
+    {
+        xADReplicationSite 'CupertinoSite'
+        {
+           Ensure = 'Absent'
+           Name   = 'Cupertino'
+        }
+    }
+}
+
+Example_xADReplicationSite
+
+Start-DscConfiguration -Path .\Example_xADReplicationSite -Wait -Verbose
 ```
 
 ### Create an Active Directory OU

--- a/Tests/Unit/MSFT_xADReplicationSite.Tests.ps1
+++ b/Tests/Unit/MSFT_xADReplicationSite.Tests.ps1
@@ -1,0 +1,244 @@
+$Global:DSCModuleName      = 'xActiveDirectory'
+$Global:DSCResourceName    = 'MSFT_xADReplicationSite'
+
+#region HEADER
+[String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
+if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'))
+}
+
+Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $Global:DSCModuleName `
+    -DSCResourceName $Global:DSCResourceName `
+    -TestType Unit
+#endregion
+
+# Begin Testing
+try
+{
+    #region Pester Tests
+
+    # The InModuleScope command allows you to perform white-box unit testing on
+    # the internal (non-exported) code of a Script Module.
+    InModuleScope $Global:DSCResourceName {
+
+        #region Pester Test Initialization
+        $presentSiteName = 'DemoSite'
+        $absentSiteName  = 'MissingSite'
+
+        $presentSiteMock = [PSCustomObject] @{
+            Name              = $presentSiteName
+            DistinguishedName = "CN=$presentSiteName,CN=Sites,CN=Configuration,DC=contoso,DC=com"
+        }
+
+        $defaultFirstSiteNameSiteMock = [PSCustomObject] @{
+            Name              = 'Default-First-Site-Name'
+            DistinguishedName = "CN=Default-First-Site-Name,CN=Sites,CN=Configuration,DC=contoso,DC=com"
+        }
+
+        $presentSiteTestPresent = @{
+            Ensure = 'Present'
+            Name   = $presentSiteName
+        }
+        $presentSiteTestAbsent = @{
+            Ensure = 'Absent'
+            Name   = $presentSiteName
+        }
+
+        $absentSiteTestPresent = @{
+            Ensure = 'Present'
+            Name   = $absentSiteName
+        }
+        $absentSiteTestAbsent = @{
+            Ensure = 'Absent'
+            Name   = $absentSiteName
+        }
+
+        $presentSiteTestPresentRename = @{
+            Ensure                     = 'Present'
+            Name                       = $presentSiteName
+            RenameDefaultFirstSiteName = $true
+        }
+        # #endregion
+
+        #region Function Get-TargetResource
+        Describe "$($Global:DSCResourceName)\Get-TargetResource" {
+
+            It 'Should return a "System.Collections.Hashtable" object type' {
+
+                # Arrange
+                Mock -CommandName 'Get-ADReplicationSite' -MockWith { $presentSiteMock }
+
+                # Act
+                $targetResource = Get-TargetResource -Name $presentSiteName
+
+                # Assert
+                $targetResource -is [System.Collections.Hashtable] | Should Be $true
+            }
+
+            It 'Should return present if the site exists' {
+
+                # Arrange
+                Mock -CommandName 'Get-ADReplicationSite' -MockWith { $presentSiteMock }
+
+                # Act
+                $targetResource = Get-TargetResource -Name $presentSiteName
+
+                # Assert
+                $targetResource.Ensure | Should Be 'Present'
+                $targetResource.Name   | Should Be $presentSiteName
+            }
+
+            It 'Should return absent if the site does not exist' {
+
+                # Arrange
+                Mock -CommandName 'Get-ADReplicationSite' -MockWith { }
+
+                # Act
+                $targetResource = Get-TargetResource -Name $absentSiteName
+
+                # Assert
+                $targetResource.Ensure | Should Be 'Absent'
+                $targetResource.Name   | Should Be $absentSiteName
+            }
+        }
+        #endregion
+
+        #region Function Test-TargetResource
+        Describe "$($Global:DSCResourceName)\Test-TargetResource" {
+
+            It 'Should return a "System.Boolean" object type' {
+
+                # Arrange
+                Mock -CommandName 'Get-ADReplicationSite' -MockWith { $presentSiteMock }
+
+                # Act
+                $targetResourceState = Test-TargetResource @presentSiteTestPresent
+
+                # Assert
+                $targetResourceState -is [System.Boolean] | Should Be $true
+            }
+
+            It 'Should return true if the site should exists and does exists' {
+
+                # Arrange
+                Mock -CommandName 'Get-ADReplicationSite' -MockWith { $presentSiteMock }
+
+                # Act
+                $targetResourceState = Test-TargetResource @presentSiteTestPresent
+
+                # Assert
+                $targetResourceState | Should Be $true
+            }
+
+            It 'Should return false if the site should exists but does not exists' {
+
+                # Arrange
+                Mock -CommandName 'Get-ADReplicationSite' -MockWith { }
+
+                # Act
+                $targetResourceState = Test-TargetResource @absentSiteTestPresent
+
+                # Assert
+                $targetResourceState | Should Be $false
+            }
+
+            It 'Should return false if the site should not exists but does exists' {
+
+                # Arrange
+                Mock -CommandName 'Get-ADReplicationSite' -MockWith { $presentSiteMock }
+
+                # Act
+                $targetResourceState = Test-TargetResource @presentSiteTestAbsent
+
+                # Assert
+                $targetResourceState | Should Be $false
+            }
+
+            It 'Should return true if the site should not exists and does not exists' {
+
+                # Arrange
+                Mock -CommandName 'Get-ADReplicationSite' -MockWith { }
+
+                # Act
+                $targetResourceState = Test-TargetResource @absentSiteTestAbsent
+
+                # Assert
+                $targetResourceState | Should Be $true
+            }
+        }
+
+        #endregion
+
+        #region Function Set-TargetResource
+        Describe "$($Global:DSCResourceName)\Set-TargetResource" {
+
+            It 'Should add a new site' {
+
+                # Arrange
+                Mock -CommandName 'Get-ADReplicationSite' -MockWith { }
+                Mock -CommandName 'New-ADReplicationSite' -Verifiable
+
+                # Act
+                Set-TargetResource @presentSiteTestPresent
+
+                # Assert
+                Assert-MockCalled -CommandName 'New-ADReplicationSite' -Times 1 -Scope It
+            }
+
+            It 'Should rename the Default-First-Site-Name if it exists' {
+
+                # Arrange
+                Mock -CommandName 'Get-ADReplicationSite' -MockWith { $defaultFirstSiteNameSiteMock }
+                Mock -CommandName 'Rename-ADObject' -Verifiable
+                Mock -CommandName 'New-ADReplicationSite' -Verifiable
+
+                # Act
+                Set-TargetResource @presentSiteTestPresentRename
+
+                # Assert
+                Assert-MockCalled -CommandName 'Rename-ADObject' -Times 1 -Scope It
+                Assert-MockCalled -CommandName 'New-ADReplicationSite' -Times 0 -Scope It
+            }
+
+            It 'Should add a new site if the Default-First-Site-Name does not exist' {
+
+                # Arrange
+                Mock -CommandName 'Get-ADReplicationSite' -MockWith { }
+                Mock -CommandName 'Rename-ADObject' -Verifiable
+                Mock -CommandName 'New-ADReplicationSite' -Verifiable
+
+                # Act
+                Set-TargetResource @presentSiteTestPresentRename
+
+                # Assert
+                Assert-MockCalled -CommandName 'Rename-ADObject' -Times 0 -Scope It
+                Assert-MockCalled -CommandName 'New-ADReplicationSite' -Times 1 -Scope It
+            }
+
+            It 'Should remove an existing site' {
+
+                # Arrange
+                Mock -CommandName 'Get-ADReplicationSite' -MockWith { $presentSiteMock }
+                Mock -CommandName 'Remove-ADReplicationSite' -Verifiable
+
+                # Act
+                Set-TargetResource @presentSiteTestAbsent
+
+                # Assert
+                Assert-MockCalled -CommandName 'Remove-ADReplicationSite' -Times 1 -Scope It
+            }
+        }
+        #endregion
+    }
+    #endregion
+}
+finally
+{
+    #region FOOTER
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+    #endregion
+}


### PR DESCRIPTION
I've added an DSC resource callled **xADReplicationSite** to add or remove Active Directory Replication Sites. Its an extension to the pull request #180. In addition, it is possible to rename the Default-First-Site-Name instead of creating a new site. This is useful for AD deployments from scratch, where the initial site is called Default-First-Site-Name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xactivedirectory/185)
<!-- Reviewable:end -->
