### PR TITLE
Resolves Issue 183

### DIFF
--- a/DSCResources/MSFT_xADGroup/MSFT_xADGroup.psm1
+++ b/DSCResources/MSFT_xADGroup/MSFT_xADGroup.psm1
@@ -244,12 +244,12 @@ function Test-TargetResource
 
     $targetResource = Get-TargetResource @PSBoundParameters;
     $targetResourceInCompliance = $true;
-    if ($targetResource.GroupScope -ne $GroupScope)
+    if ($PSBoundParameters.ContainsKey('GroupScope') -and $targetResource.GroupScope -ne $GroupScope)
     {
         Write-Verbose ($LocalizedData.NotDesiredPropertyState -f 'GroupScope', $GroupScope, $targetResource.GroupScope);
         $targetResourceInCompliance = $false;
     }
-    if ($targetResource.Category -ne $Category)
+    if ($PSBoundParameters.ContainsKey('Category') -and $targetResource.Category -ne $Category)
     {
         Write-Verbose ($LocalizedData.NotDesiredPropertyState -f 'Category', $Category, $targetResource.Category);
         $targetResourceInCompliance = $false;

--- a/DSCResources/MSFT_xADGroup/MSFT_xADGroup.psm1
+++ b/DSCResources/MSFT_xADGroup/MSFT_xADGroup.psm1
@@ -131,7 +131,8 @@ function Get-TargetResource
             $targetResource['Ensure'] = 'Present'
         }
     }
-    catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException] {
+    catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException]
+    {
         Write-Verbose ($LocalizedData.GroupNotFound -f $GroupName)
         $targetResource = @{
             GroupName = $GroupName
@@ -387,7 +388,6 @@ function Set-TargetResource
 
         if ($Ensure -eq 'Present')
         {
-
             $setADGroupParams = $adGroupParams.Clone()
             $setADGroupParams['Identity'] = $adGroup.DistinguishedName
 
@@ -481,7 +481,6 @@ function Set-TargetResource
         ## The AD group doesn't exist
         if ($Ensure -eq 'Present')
         {
-
             Write-Verbose ($LocalizedData.GroupNotFound -f $GroupName)
             Write-Verbose ($LocalizedData.AddingGroup -f $GroupName)
 

--- a/DSCResources/MSFT_xADGroup/MSFT_xADGroup.psm1
+++ b/DSCResources/MSFT_xADGroup/MSFT_xADGroup.psm1
@@ -1,7 +1,7 @@
 # Localized messages
 data LocalizedData
 {
-    # culture="en-US"
+    # culture='en-US'
     ConvertFrom-StringData @'
         RetrievingGroupMembers         = Retrieving group membership based on '{0}' property.
         GroupMembershipInDesiredState  = Group membership is in the desired state.
@@ -46,9 +46,9 @@ function Get-TargetResource
         $Path,
 
         [Parameter()]
-        [ValidateSet("Present", "Absent")]
+        [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure = "Present",
+        $Ensure = 'Present',
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
@@ -173,9 +173,9 @@ function Test-TargetResource
         $Path,
 
         [Parameter()]
-        [ValidateSet("Present", "Absent")]
+        [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure = "Present",
+        $Ensure = 'Present',
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
@@ -319,9 +319,9 @@ function Set-TargetResource
         $Path,
 
         [Parameter()]
-        [ValidateSet("Present", "Absent")]
+        [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure = "Present",
+        $Ensure = 'Present',
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]

--- a/DSCResources/MSFT_xADGroup/MSFT_xADGroup.psm1
+++ b/DSCResources/MSFT_xADGroup/MSFT_xADGroup.psm1
@@ -381,10 +381,12 @@ function Set-TargetResource
     Assert-Module -ModuleName 'ActiveDirectory'
     $adGroupParams = Get-ADCommonParameters @PSBoundParameters
 
-    try {
+    try
+    {
         $adGroup = Get-ADGroup @adGroupParams -Property Name,GroupScope,GroupCategory,DistinguishedName,Description,DisplayName,ManagedBy,Info
 
-        if ($Ensure -eq 'Present') {
+        if ($Ensure -eq 'Present')
+        {
 
             $setADGroupParams = $adGroupParams.Clone()
             $setADGroupParams['Identity'] = $adGroup.DistinguishedName
@@ -426,7 +428,8 @@ function Set-TargetResource
             Set-ADGroup @setADGroupParams
 
             # Move group if the path is not correct
-            if ($Path -and ($Path -ne (Get-ADObjectParentDN -DN $adGroup.DistinguishedName))) {
+            if ($Path -and ($Path -ne (Get-ADObjectParentDN -DN $adGroup.DistinguishedName)))
+            {
                 Write-Verbose ($LocalizedData.MovingGroup -f $GroupName, $Path)
                 $moveADObjectParams = $adGroupParams.Clone()
                 $moveADObjectParams['Identity'] = $adGroup.DistinguishedName
@@ -506,7 +509,8 @@ function Set-TargetResource
             ## the parameters with the -Identity parameter rather than -Name
             $adGroupParams = Get-ADCommonParameters @PSBoundParameters
 
-            if ($Notes) {
+            if ($Notes)
+            {
                 ## Can't set the Notes field when creating the group
                 Write-Verbose ($LocalizedData.UpdatingGroupProperty -f 'Notes', $Notes)
                 $setADGroupParams = $adGroupParams.Clone()

--- a/DSCResources/MSFT_xADGroup/MSFT_xADGroup.psm1
+++ b/DSCResources/MSFT_xADGroup/MSFT_xADGroup.psm1
@@ -1,4 +1,4 @@
-## Import the common AD functions
+# Import the common AD functions
 $adCommonFunctions = Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -ChildPath '\MSFT_xADCommon\MSFT_xADCommon.ps1'
 . $adCommonFunctions
 
@@ -92,7 +92,7 @@ function Get-TargetResource
         [System.String]
         $MembershipAttribute = 'SamAccountName',
 
-        ## This must be the user's DN
+        # This must be the user's DN
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
@@ -109,7 +109,7 @@ function Get-TargetResource
     {
         $adGroup = Get-ADGroup @adGroupParams -Property Name,GroupScope,GroupCategory,DistinguishedName,Description,DisplayName,ManagedBy,Info
         Write-Verbose -Message ($LocalizedData.RetrievingGroupMembers -f $MembershipAttribute)
-        ## Retrieve the current list of members, returning the specified membership attribute
+        # Retrieve the current list of members, returning the specified membership attribute
         [System.Array]$adGroupMembers = (Get-ADGroupMember @adGroupParams).$MembershipAttribute
         $targetResource = @{
             GroupName = $adGroup.Name
@@ -221,7 +221,7 @@ function Test-TargetResource
         [System.String]
         $MembershipAttribute = 'SamAccountName',
 
-        ## This must be the user's DN
+        # This must be the user's DN
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
@@ -232,7 +232,7 @@ function Test-TargetResource
         [System.String]
         $Notes
     )
-    ## Validate parameters before we even attempt to retrieve anything
+    # Validate parameters before we even attempt to retrieve anything
     $assertMemberParameters = @{}
     if ($PSBoundParameters.ContainsKey('Members') -and -not [system.string]::IsNullOrEmpty($Members))
     {
@@ -285,7 +285,7 @@ function Test-TargetResource
         Write-Verbose ($LocalizedData.NotDesiredPropertyState -f 'Notes', $Notes, $targetResource.Notes)
         $targetResourceInCompliance = $false
     }
-    ## Test group members match passed membership parameters
+    # Test group members match passed membership parameters
     if (-not (Test-Members @assertMemberParameters -ExistingMembers $targetResource.Members))
     {
         Write-Verbose -Message $LocalizedData.GroupMembershipNotDesiredState
@@ -367,7 +367,7 @@ function Set-TargetResource
         [System.String]
         $MembershipAttribute = 'SamAccountName',
 
-        ## This must be the user's DN
+        # This must be the user's DN
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
@@ -399,7 +399,7 @@ function Set-TargetResource
             }
             if ($PSBoundParameters.ContainsKey('GroupScope') -and $GroupScope -ne $adGroup.GroupScope)
             {
-                ## Cannot change DomainLocal to Global or vice versa directly. Need to change them to a Universal group first!
+                # Cannot change DomainLocal to Global or vice versa directly. Need to change them to a Universal group first!
                 Set-ADGroup -Identity $adGroup.DistinguishedName -GroupScope Universal
                 Write-Verbose ($LocalizedData.UpdatingGroupProperty -f 'GroupScope', $GroupScope)
                 $setADGroupParams['GroupScope'] = $GroupScope
@@ -440,8 +440,8 @@ function Set-TargetResource
             $adGroupMembers = (Get-ADGroupMember @adGroupParams).$MembershipAttribute
             if (-not (Test-Members -ExistingMembers $adGroupMembers -Members $Members -MembersToInclude $MembersToInclude -MembersToExclude $MembersToExclude))
             {
-                ## The fact that we're in the Set method, there is no need to validate the parameter
-                ## combination as this was performed in the Test method
+                # The fact that we're in the Set method, there is no need to validate the parameter
+                # combination as this was performed in the Test method
                 if ($PSBoundParameters.ContainsKey('Members') -and -not [system.string]::IsNullOrEmpty($Members))
                 {
                     # Remove all existing first and add explicit members
@@ -478,7 +478,7 @@ function Set-TargetResource
     }
     catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException]
     {
-        ## The AD group doesn't exist
+        # The AD group doesn't exist
         if ($Ensure -eq 'Present')
         {
             Write-Verbose ($LocalizedData.GroupNotFound -f $GroupName)
@@ -501,23 +501,23 @@ function Set-TargetResource
             {
                 $adGroupParams['Path'] = $Path
             }
-            ## Create group
+            # Create group
             $adGroup = New-ADGroup @adGroupParams -GroupCategory $Category -GroupScope $GroupScope -PassThru
 
-            ## Only the New-ADGroup cmdlet takes a -Name parameter. Refresh
-            ## the parameters with the -Identity parameter rather than -Name
+            # Only the New-ADGroup cmdlet takes a -Name parameter. Refresh
+            # the parameters with the -Identity parameter rather than -Name
             $adGroupParams = Get-ADCommonParameters @PSBoundParameters
 
             if ($Notes)
             {
-                ## Can't set the Notes field when creating the group
+                # Can't set the Notes field when creating the group
                 Write-Verbose ($LocalizedData.UpdatingGroupProperty -f 'Notes', $Notes)
                 $setADGroupParams = $adGroupParams.Clone()
                 $setADGroupParams['Identity'] = $adGroup.DistinguishedName
                 Set-ADGroup @setADGroupParams -Add @{ Info = $Notes }
             }
 
-            ## Add the required members
+            # Add the required members
             if ($PSBoundParameters.ContainsKey('Members') -and -not [system.string]::IsNullOrEmpty($Members))
             {
                 $Members = Remove-DuplicateMembers -Members $Members

--- a/DSCResources/MSFT_xADGroup/MSFT_xADGroup.psm1
+++ b/DSCResources/MSFT_xADGroup/MSFT_xADGroup.psm1
@@ -99,52 +99,53 @@ function Get-TargetResource
         [System.String]
         $Notes
     )
-    Assert-Module -ModuleName 'ActiveDirectory';
-    $adGroupParams = Get-ADCommonParameters @PSBoundParameters;
-    try {
-        $adGroup = Get-ADGroup @adGroupParams -Property Name,GroupScope,GroupCategory,DistinguishedName,Description,DisplayName,ManagedBy,Info;
-        Write-Verbose -Message ($LocalizedData.RetrievingGroupMembers -f $MembershipAttribute);
+    Assert-Module -ModuleName 'ActiveDirectory'
+    $adGroupParams = Get-ADCommonParameters @PSBoundParameters
+    try
+    {
+        $adGroup = Get-ADGroup @adGroupParams -Property Name,GroupScope,GroupCategory,DistinguishedName,Description,DisplayName,ManagedBy,Info
+        Write-Verbose -Message ($LocalizedData.RetrievingGroupMembers -f $MembershipAttribute)
         ## Retrieve the current list of members, returning the specified membership attribute
-        [System.Array]$adGroupMembers = (Get-ADGroupMember @adGroupParams).$MembershipAttribute;
+        [System.Array]$adGroupMembers = (Get-ADGroupMember @adGroupParams).$MembershipAttribute
         $targetResource = @{
-            GroupName = $adGroup.Name;
-            GroupScope = $adGroup.GroupScope;
-            Category = $adGroup.GroupCategory;
-            Path = Get-ADObjectParentDN -DN $adGroup.DistinguishedName;
-            Description = $adGroup.Description;
-            DisplayName = $adGroup.DisplayName;
-            Members = $adGroupMembers;
-            MembersToInclude = $MembersToInclude;
-            MembersToExclude = $MembersToExclude;
-            MembershipAttribute = $MembershipAttribute;
-            ManagedBy = $adGroup.ManagedBy;
-            Notes = $adGroup.Info;
-            Ensure = 'Absent';
+            GroupName = $adGroup.Name
+            GroupScope = $adGroup.GroupScope
+            Category = $adGroup.GroupCategory
+            Path = Get-ADObjectParentDN -DN $adGroup.DistinguishedName
+            Description = $adGroup.Description
+            DisplayName = $adGroup.DisplayName
+            Members = $adGroupMembers
+            MembersToInclude = $MembersToInclude
+            MembersToExclude = $MembersToExclude
+            MembershipAttribute = $MembershipAttribute
+            ManagedBy = $adGroup.ManagedBy
+            Notes = $adGroup.Info
+            Ensure = 'Absent'
         }
         if ($adGroup)
         {
-            $targetResource['Ensure'] = 'Present';
+            $targetResource['Ensure'] = 'Present'
         }
     }
     catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException] {
-        Write-Verbose ($LocalizedData.GroupNotFound -f $GroupName);
+        Write-Verbose ($LocalizedData.GroupNotFound -f $GroupName)
         $targetResource = @{
-            GroupName = $GroupName;
-            GroupScope = $GroupScope;
-            Category = $Category;
-            Path = $Path;
-            Description = $Description;
-            DisplayName = $DisplayName;
-            Members = @();
-            MembersToInclude = $MembersToInclude;
-            MembersToExclude = $MembersToExclude;
-            MembershipAttribute = $MembershipAttribute;
-            ManagedBy = $ManagedBy;
-            Notes = $Notes;
-            Ensure = 'Absent';
+            GroupName = $GroupName
+            GroupScope = $GroupScope
+            Category = $Category
+            Path = $Path
+            Description = $Description
+            DisplayName = $DisplayName
+            Members = @()
+            MembersToInclude = $MembersToInclude
+            MembersToExclude = $MembersToExclude
+            MembershipAttribute = $MembershipAttribute
+            ManagedBy = $ManagedBy
+            Notes = $Notes
+            Ensure = 'Absent'
         }
     }
-    return $targetResource;
+    return $targetResource
 } #end function Get-TargetResource
 
 function Test-TargetResource
@@ -227,70 +228,70 @@ function Test-TargetResource
         $Notes
     )
     ## Validate parameters before we even attempt to retrieve anything
-    $assertMemberParameters = @{};
+    $assertMemberParameters = @{}
     if ($PSBoundParameters.ContainsKey('Members') -and -not [system.string]::IsNullOrEmpty($Members))
     {
-        $assertMemberParameters['Members'] = $Members;
+        $assertMemberParameters['Members'] = $Members
     }
     if ($PSBoundParameters.ContainsKey('MembersToInclude') -and -not [system.string]::IsNullOrEmpty($MembersToInclude))
     {
-        $assertMemberParameters['MembersToInclude'] = $MembersToInclude;
+        $assertMemberParameters['MembersToInclude'] = $MembersToInclude
     }
     if ($PSBoundParameters.ContainsKey('MembersToExclude') -and -not [system.string]::IsNullOrEmpty($MembersToExclude))
     {
-        $assertMemberParameters['MembersToExclude'] = $MembersToExclude;
+        $assertMemberParameters['MembersToExclude'] = $MembersToExclude
     }
-    Assert-MemberParameters @assertMemberParameters -ModuleName 'xADDomain' -ErrorAction Stop;
+    Assert-MemberParameters @assertMemberParameters -ModuleName 'xADDomain' -ErrorAction Stop
 
-    $targetResource = Get-TargetResource @PSBoundParameters;
-    $targetResourceInCompliance = $true;
+    $targetResource = Get-TargetResource @PSBoundParameters
+    $targetResourceInCompliance = $true
     if ($PSBoundParameters.ContainsKey('GroupScope') -and $targetResource.GroupScope -ne $GroupScope)
     {
-        Write-Verbose ($LocalizedData.NotDesiredPropertyState -f 'GroupScope', $GroupScope, $targetResource.GroupScope);
-        $targetResourceInCompliance = $false;
+        Write-Verbose ($LocalizedData.NotDesiredPropertyState -f 'GroupScope', $GroupScope, $targetResource.GroupScope)
+        $targetResourceInCompliance = $false
     }
     if ($PSBoundParameters.ContainsKey('Category') -and $targetResource.Category -ne $Category)
     {
-        Write-Verbose ($LocalizedData.NotDesiredPropertyState -f 'Category', $Category, $targetResource.Category);
-        $targetResourceInCompliance = $false;
+        Write-Verbose ($LocalizedData.NotDesiredPropertyState -f 'Category', $Category, $targetResource.Category)
+        $targetResourceInCompliance = $false
     }
     if ($Path -and ($targetResource.Path -ne $Path))
     {
-        Write-Verbose ($LocalizedData.NotDesiredPropertyState -f 'Path', $Path, $targetResource.Path);
-        $targetResourceInCompliance = $false;
+        Write-Verbose ($LocalizedData.NotDesiredPropertyState -f 'Path', $Path, $targetResource.Path)
+        $targetResourceInCompliance = $false
     }
     if ($Description -and ($targetResource.Description -ne $Description))
     {
-        Write-Verbose ($LocalizedData.NotDesiredPropertyState -f 'Description', $Description, $targetResource.Description);
-        $targetResourceInCompliance = $false;
+        Write-Verbose ($LocalizedData.NotDesiredPropertyState -f 'Description', $Description, $targetResource.Description)
+        $targetResourceInCompliance = $false
     }
     if ($DisplayName -and ($targetResource.DisplayName -ne $DisplayName))
     {
-        Write-Verbose ($LocalizedData.NotDesiredPropertyState -f 'DisplayName', $DisplayName, $targetResource.DisplayName);
-        $targetResourceInCompliance = $false;
+        Write-Verbose ($LocalizedData.NotDesiredPropertyState -f 'DisplayName', $DisplayName, $targetResource.DisplayName)
+        $targetResourceInCompliance = $false
     }
     if ($ManagedBy -and ($targetResource.ManagedBy -ne $ManagedBy))
     {
-        Write-Verbose ($LocalizedData.NotDesiredPropertyState -f 'ManagedBy', $ManagedBy, $targetResource.ManagedBy);
-        $targetResourceInCompliance = $false;
+        Write-Verbose ($LocalizedData.NotDesiredPropertyState -f 'ManagedBy', $ManagedBy, $targetResource.ManagedBy)
+        $targetResourceInCompliance = $false
     }
     if ($Notes -and ($targetResource.Notes -ne $Notes))
     {
-        Write-Verbose ($LocalizedData.NotDesiredPropertyState -f 'Notes', $Notes, $targetResource.Notes);
-        $targetResourceInCompliance = $false;
+        Write-Verbose ($LocalizedData.NotDesiredPropertyState -f 'Notes', $Notes, $targetResource.Notes)
+        $targetResourceInCompliance = $false
     }
     ## Test group members match passed membership parameters
     if (-not (Test-Members @assertMemberParameters -ExistingMembers $targetResource.Members))
     {
-        Write-Verbose -Message $LocalizedData.GroupMembershipNotDesiredState;
-        $targetResourceInCompliance = $false;
+        Write-Verbose -Message $LocalizedData.GroupMembershipNotDesiredState
+        $targetResourceInCompliance = $false
     }
     if ($targetResource.Ensure -ne $Ensure)
     {
-        Write-Verbose ($LocalizedData.NotDesiredPropertyState -f 'Ensure', $Ensure, $targetResource.Ensure);
-        $targetResourceInCompliance = $false;
+        Write-Verbose ($LocalizedData.NotDesiredPropertyState -f 'Ensure', $Ensure, $targetResource.Ensure)
+        $targetResourceInCompliance = $false
     }
-    return $targetResourceInCompliance;
+    return $targetResourceInCompliance
 } #end function Test-TargetResource
 
 function Set-TargetResource
@@ -373,63 +374,63 @@ function Set-TargetResource
         $Notes
 
     )
-    Assert-Module -ModuleName 'ActiveDirectory';
-    $adGroupParams = Get-ADCommonParameters @PSBoundParameters;
+    Assert-Module -ModuleName 'ActiveDirectory'
+    $adGroupParams = Get-ADCommonParameters @PSBoundParameters
 
     try {
-        $adGroup = Get-ADGroup @adGroupParams -Property Name,GroupScope,GroupCategory,DistinguishedName,Description,DisplayName,ManagedBy,Info;
+        $adGroup = Get-ADGroup @adGroupParams -Property Name,GroupScope,GroupCategory,DistinguishedName,Description,DisplayName,ManagedBy,Info
 
         if ($Ensure -eq 'Present') {
 
-            $setADGroupParams = $adGroupParams.Clone();
-            $setADGroupParams['Identity'] = $adGroup.DistinguishedName;
+            $setADGroupParams = $adGroupParams.Clone()
+            $setADGroupParams['Identity'] = $adGroup.DistinguishedName
 
             # Update existing group properties
             if ($Category -ne $adGroup.GroupCategory)
             {
-                Write-Verbose ($LocalizedData.UpdatingGroupProperty -f 'Category', $Category);
-                $setADGroupParams['GroupCategory'] = $Category;
+                Write-Verbose ($LocalizedData.UpdatingGroupProperty -f 'Category', $Category)
+                $setADGroupParams['GroupCategory'] = $Category
             }
             if ($GroupScope -ne $adGroup.GroupScope)
             {
                 ## Cannot change DomainLocal to Global or vice versa directly. Need to change them to a Universal group first!
-                Set-ADGroup -Identity $adGroup.DistinguishedName -GroupScope Universal;
-                Write-Verbose ($LocalizedData.UpdatingGroupProperty -f 'GroupScope', $GroupScope);
-                $setADGroupParams['GroupScope'] = $GroupScope;
+                Set-ADGroup -Identity $adGroup.DistinguishedName -GroupScope Universal
+                Write-Verbose ($LocalizedData.UpdatingGroupProperty -f 'GroupScope', $GroupScope)
+                $setADGroupParams['GroupScope'] = $GroupScope
             }
             if ($Description -and ($Description -ne $adGroup.Description))
             {
-                Write-Verbose ($LocalizedData.UpdatingGroupProperty -f 'Description', $Description);
-                $setADGroupParams['Description'] = $Description;
+                Write-Verbose ($LocalizedData.UpdatingGroupProperty -f 'Description', $Description)
+                $setADGroupParams['Description'] = $Description
             }
             if ($DisplayName -and ($DisplayName -ne $adGroup.DisplayName))
             {
-                Write-Verbose ($LocalizedData.UpdatingGroupProperty -f 'DisplayName', $DisplayName);
-                $setADGroupParams['DisplayName'] = $DisplayName;
+                Write-Verbose ($LocalizedData.UpdatingGroupProperty -f 'DisplayName', $DisplayName)
+                $setADGroupParams['DisplayName'] = $DisplayName
             }
             if ($ManagedBy -and ($ManagedBy -ne $adGroup.ManagedBy))
             {
-                Write-Verbose ($LocalizedData.UpdatingGroupProperty -f 'ManagedBy', $ManagedBy);
-                $setADGroupParams['ManagedBy'] = $ManagedBy;
+                Write-Verbose ($LocalizedData.UpdatingGroupProperty -f 'ManagedBy', $ManagedBy)
+                $setADGroupParams['ManagedBy'] = $ManagedBy
             }
             if ($Notes -and ($Notes -ne $adGroup.Info))
             {
-                Write-Verbose ($LocalizedData.UpdatingGroupProperty -f 'Notes', $Notes);
-                $setADGroupParams['Replace'] = @{ Info = $Notes };
+                Write-Verbose ($LocalizedData.UpdatingGroupProperty -f 'Notes', $Notes)
+                $setADGroupParams['Replace'] = @{ Info = $Notes }
             }
-            Write-Verbose ($LocalizedData.UpdatingGroup -f $GroupName);
-            Set-ADGroup @setADGroupParams;
+            Write-Verbose ($LocalizedData.UpdatingGroup -f $GroupName)
+            Set-ADGroup @setADGroupParams
 
             # Move group if the path is not correct
             if ($Path -and ($Path -ne (Get-ADObjectParentDN -DN $adGroup.DistinguishedName))) {
-                Write-Verbose ($LocalizedData.MovingGroup -f $GroupName, $Path);
-                $moveADObjectParams = $adGroupParams.Clone();
+                Write-Verbose ($LocalizedData.MovingGroup -f $GroupName, $Path)
+                $moveADObjectParams = $adGroupParams.Clone()
                 $moveADObjectParams['Identity'] = $adGroup.DistinguishedName
-                Move-ADObject @moveADObjectParams -TargetPath $Path;
+                Move-ADObject @moveADObjectParams -TargetPath $Path
             }
 
-            Write-Verbose -Message ($LocalizedData.RetrievingGroupMembers -f $MembershipAttribute);
-            $adGroupMembers = (Get-ADGroupMember @adGroupParams).$MembershipAttribute;
+            Write-Verbose -Message ($LocalizedData.RetrievingGroupMembers -f $MembershipAttribute)
+            $adGroupMembers = (Get-ADGroupMember @adGroupParams).$MembershipAttribute
             if (-not (Test-Members -ExistingMembers $adGroupMembers -Members $Members -MembersToInclude $MembersToInclude -MembersToExclude $MembersToExclude))
             {
                 ## The fact that we're in the Set method, there is no need to validate the parameter
@@ -437,35 +438,35 @@ function Set-TargetResource
                 if ($PSBoundParameters.ContainsKey('Members') -and -not [system.string]::IsNullOrEmpty($Members))
                 {
                     # Remove all existing first and add explicit members
-                    $Members = Remove-DuplicateMembers -Members $Members;
+                    $Members = Remove-DuplicateMembers -Members $Members
                     # We can only remove members if there are members already in the group!
                     if ($adGroupMembers.Count -gt 0)
                     {
-                        Write-Verbose -Message ($LocalizedData.RemovingGroupMembers -f $adGroupMembers.Count, $GroupName);
-                        Remove-ADGroupMember @adGroupParams -Members $adGroupMembers -Confirm:$false;
+                        Write-Verbose -Message ($LocalizedData.RemovingGroupMembers -f $adGroupMembers.Count, $GroupName)
+                        Remove-ADGroupMember @adGroupParams -Members $adGroupMembers -Confirm:$false
                     }
-                    Write-Verbose -Message ($LocalizedData.AddingGroupMembers -f $Members.Count, $GroupName);
-                    Add-ADGroupMember @adGroupParams -Members $Members;
+                    Write-Verbose -Message ($LocalizedData.AddingGroupMembers -f $Members.Count, $GroupName)
+                    Add-ADGroupMember @adGroupParams -Members $Members
                 }
                 if ($PSBoundParameters.ContainsKey('MembersToInclude') -and -not [system.string]::IsNullOrEmpty($MembersToInclude))
                 {
-                    $MembersToInclude = Remove-DuplicateMembers -Members $MembersToInclude;
-                    Write-Verbose -Message ($LocalizedData.AddingGroupMembers -f $MembersToInclude.Count, $GroupName);
-                    Add-ADGroupMember @adGroupParams -Members $MembersToInclude;
+                    $MembersToInclude = Remove-DuplicateMembers -Members $MembersToInclude
+                    Write-Verbose -Message ($LocalizedData.AddingGroupMembers -f $MembersToInclude.Count, $GroupName)
+                    Add-ADGroupMember @adGroupParams -Members $MembersToInclude
                 }
                 if ($PSBoundParameters.ContainsKey('MembersToExclude') -and -not [system.string]::IsNullOrEmpty($MembersToExclude))
                 {
-                    $MembersToExclude = Remove-DuplicateMembers -Members $MembersToExclude;
-                    Write-Verbose -Message ($LocalizedData.RemovingGroupMembers -f $MembersToExclude.Count, $GroupName);
-                    Remove-ADGroupMember @adGroupParams -Members $MembersToExclude -Confirm:$false;
+                    $MembersToExclude = Remove-DuplicateMembers -Members $MembersToExclude
+                    Write-Verbose -Message ($LocalizedData.RemovingGroupMembers -f $MembersToExclude.Count, $GroupName)
+                    Remove-ADGroupMember @adGroupParams -Members $MembersToExclude -Confirm:$false
                 }
             }
         }
         elseif ($Ensure -eq 'Absent')
         {
             # Remove existing group
-            Write-Verbose ($LocalizedData.RemovingGroup -f $GroupName);
-            Remove-ADGroup @adGroupParams -Confirm:$false;
+            Write-Verbose ($LocalizedData.RemovingGroup -f $GroupName)
+            Remove-ADGroup @adGroupParams -Confirm:$false
         }
     }
     catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException]
@@ -474,28 +475,28 @@ function Set-TargetResource
         if ($Ensure -eq 'Present')
         {
 
-            Write-Verbose ($LocalizedData.GroupNotFound -f $GroupName);
-            Write-Verbose ($LocalizedData.AddingGroup -f $GroupName);
+            Write-Verbose ($LocalizedData.GroupNotFound -f $GroupName)
+            Write-Verbose ($LocalizedData.AddingGroup -f $GroupName)
 
-            $adGroupParams = Get-ADCommonParameters @PSBoundParameters -UseNameParameter;
+            $adGroupParams = Get-ADCommonParameters @PSBoundParameters -UseNameParameter
             if ($Description)
             {
-                $adGroupParams['Description'] = $Description;
+                $adGroupParams['Description'] = $Description
             }
             if ($DisplayName)
             {
-                $adGroupParams['DisplayName'] = $DisplayName;
+                $adGroupParams['DisplayName'] = $DisplayName
             }
             if ($ManagedBy)
             {
-                $adGroupParams['ManagedBy'] = $ManagedBy;
+                $adGroupParams['ManagedBy'] = $ManagedBy
             }
             if ($Path)
             {
-                $adGroupParams['Path'] = $Path;
+                $adGroupParams['Path'] = $Path
             }
             ## Create group
-            $adGroup = New-ADGroup @adGroupParams -GroupCategory $Category -GroupScope $GroupScope -PassThru;
+            $adGroup = New-ADGroup @adGroupParams -GroupCategory $Category -GroupScope $GroupScope -PassThru
 
             ## Only the New-ADGroup cmdlet takes a -Name parameter. Refresh
             ## the parameters with the -Identity parameter rather than -Name
@@ -503,24 +504,24 @@ function Set-TargetResource
 
             if ($Notes) {
                 ## Can't set the Notes field when creating the group
-                Write-Verbose ($LocalizedData.UpdatingGroupProperty -f 'Notes', $Notes);
-                $setADGroupParams = $adGroupParams.Clone();
-                $setADGroupParams['Identity'] = $adGroup.DistinguishedName;
-                Set-ADGroup @setADGroupParams -Add @{ Info = $Notes };
+                Write-Verbose ($LocalizedData.UpdatingGroupProperty -f 'Notes', $Notes)
+                $setADGroupParams = $adGroupParams.Clone()
+                $setADGroupParams['Identity'] = $adGroup.DistinguishedName
+                Set-ADGroup @setADGroupParams -Add @{ Info = $Notes }
             }
 
             ## Add the required members
             if ($PSBoundParameters.ContainsKey('Members') -and -not [system.string]::IsNullOrEmpty($Members))
             {
-                $Members = Remove-DuplicateMembers -Members $Members;
-                Write-Verbose -Message ($LocalizedData.AddingGroupMembers -f $Members.Count, $GroupName);
-                Add-ADGroupMember @adGroupParams -Members $Members;
+                $Members = Remove-DuplicateMembers -Members $Members
+                Write-Verbose -Message ($LocalizedData.AddingGroupMembers -f $Members.Count, $GroupName)
+                Add-ADGroupMember @adGroupParams -Members $Members
             }
             elseif ($PSBoundParameters.ContainsKey('MembersToInclude') -and -not [system.string]::IsNullOrEmpty($MembersToInclude))
             {
-                $MembersToInclude = Remove-DuplicateMembers -Members $MembersToInclude;
-                Write-Verbose -Message ($LocalizedData.AddingGroupMembers -f $MembersToInclude.Count, $GroupName);
-                Add-ADGroupMember @adGroupParams -Members $MembersToInclude;
+                $MembersToInclude = Remove-DuplicateMembers -Members $MembersToInclude
+                Write-Verbose -Message ($LocalizedData.AddingGroupMembers -f $MembersToInclude.Count, $GroupName)
+                Add-ADGroupMember @adGroupParams -Members $MembersToInclude
             }
 
         }
@@ -528,7 +529,7 @@ function Set-TargetResource
 } #end function Set-TargetResource
 
 ## Import the common AD functions
-$adCommonFunctions = Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -ChildPath '\MSFT_xADCommon\MSFT_xADCommon.ps1';
-. $adCommonFunctions;
+$adCommonFunctions = Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -ChildPath '\MSFT_xADCommon\MSFT_xADCommon.ps1'
+. $adCommonFunctions
 
-Export-ModuleMember -Function *-TargetResource;
+Export-ModuleMember -Function *-TargetResource

--- a/DSCResources/MSFT_xADGroup/MSFT_xADGroup.psm1
+++ b/DSCResources/MSFT_xADGroup/MSFT_xADGroup.psm1
@@ -25,62 +25,76 @@ function Get-TargetResource
     [OutputType([System.Collections.Hashtable])]
     param
     (
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
         $GroupName,
 
+        [Parameter()]
         [ValidateSet('DomainLocal','Global','Universal')]
         [System.String]
         $GroupScope = 'Global',
 
+        [Parameter()]
         [ValidateSet('Security','Distribution')]
         [System.String]
         $Category = 'Security',
 
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
         $Path,
 
+        [Parameter()]
         [ValidateSet("Present", "Absent")]
         [System.String]
         $Ensure = "Present",
 
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
         $Description,
 
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
         $DisplayName,
 
+        [Parameter()]
         [ValidateNotNull()]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.CredentialAttribute()]
         $Credential,
 
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
         $DomainController,
 
+        [Parameter()]
         [System.String[]]
         $Members,
 
+        [Parameter()]
         [System.String[]]
         $MembersToInclude,
 
+        [Parameter()]
         [System.String[]]
         $MembersToExclude,
 
+        [Parameter()]
         [ValidateSet('SamAccountName','DistinguishedName','SID','ObjectGUID')]
         [System.String]
         $MembershipAttribute = 'SamAccountName',
 
         ## This must be the user's DN
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
         $ManagedBy,
 
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
         $Notes
@@ -138,62 +152,76 @@ function Test-TargetResource
     [CmdletBinding()]
     [OutputType([System.Boolean])]
     param (
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
         $GroupName,
 
+        [Parameter()]
         [ValidateSet('DomainLocal','Global','Universal')]
         [System.String]
         $GroupScope = 'Global',
 
+        [Parameter()]
         [ValidateSet('Security','Distribution')]
         [System.String]
         $Category = 'Security',
 
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
         $Path,
 
+        [Parameter()]
         [ValidateSet("Present", "Absent")]
         [System.String]
         $Ensure = "Present",
 
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
         $Description,
 
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
         $DisplayName,
 
+        [Parameter()]
         [ValidateNotNull()]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.CredentialAttribute()]
         $Credential,
 
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
         $DomainController,
 
+        [Parameter()]
         [System.String[]]
         $Members,
 
+        [Parameter()]
         [System.String[]]
         $MembersToInclude,
 
+        [Parameter()]
         [System.String[]]
         $MembersToExclude,
 
+        [Parameter()]
         [ValidateSet('SamAccountName','DistinguishedName','SID','ObjectGUID')]
         [System.String]
         $MembershipAttribute = 'SamAccountName',
 
         ## This must be the user's DN
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
         $ManagedBy,
 
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
         $Notes
@@ -270,62 +298,76 @@ function Set-TargetResource
     [CmdletBinding()]
     param
     (
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
         $GroupName,
 
+        [Parameter()]
         [ValidateSet('DomainLocal','Global','Universal')]
         [System.String]
         $GroupScope = 'Global',
 
+        [Parameter()]
         [ValidateSet('Security','Distribution')]
         [System.String]
         $Category = 'Security',
 
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
         $Path,
 
+        [Parameter()]
         [ValidateSet("Present", "Absent")]
         [System.String]
         $Ensure = "Present",
 
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
         $Description,
 
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
         $DisplayName,
 
+        [Parameter()]
         [ValidateNotNull()]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.CredentialAttribute()]
         $Credential,
 
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
         $DomainController,
 
+        [Parameter()]
         [System.String[]]
         $Members,
 
+        [Parameter()]
         [System.String[]]
         $MembersToInclude,
 
+        [Parameter()]
         [System.String[]]
         $MembersToExclude,
 
+        [Parameter()]
         [ValidateSet('SamAccountName','DistinguishedName','SID','ObjectGUID')]
         [System.String]
         $MembershipAttribute = 'SamAccountName',
 
         ## This must be the user's DN
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
         $ManagedBy,
 
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
         $Notes

--- a/DSCResources/MSFT_xADGroup/MSFT_xADGroup.psm1
+++ b/DSCResources/MSFT_xADGroup/MSFT_xADGroup.psm1
@@ -392,12 +392,12 @@ function Set-TargetResource
             $setADGroupParams['Identity'] = $adGroup.DistinguishedName
 
             # Update existing group properties
-            if ($Category -ne $adGroup.GroupCategory)
+            if ($PSBoundParameters.ContainsKey('Category') -and $Category -ne $adGroup.GroupCategory)
             {
                 Write-Verbose ($LocalizedData.UpdatingGroupProperty -f 'Category', $Category)
                 $setADGroupParams['GroupCategory'] = $Category
             }
-            if ($GroupScope -ne $adGroup.GroupScope)
+            if ($PSBoundParameters.ContainsKey('GroupScope') -and $GroupScope -ne $adGroup.GroupScope)
             {
                 ## Cannot change DomainLocal to Global or vice versa directly. Need to change them to a Universal group first!
                 Set-ADGroup -Identity $adGroup.DistinguishedName -GroupScope Universal

--- a/DSCResources/MSFT_xADGroup/MSFT_xADGroup.psm1
+++ b/DSCResources/MSFT_xADGroup/MSFT_xADGroup.psm1
@@ -1,3 +1,7 @@
+## Import the common AD functions
+$adCommonFunctions = Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -ChildPath '\MSFT_xADCommon\MSFT_xADCommon.ps1'
+. $adCommonFunctions
+
 # Localized messages
 data LocalizedData
 {
@@ -527,9 +531,5 @@ function Set-TargetResource
         }
     } #end catch
 } #end function Set-TargetResource
-
-## Import the common AD functions
-$adCommonFunctions = Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -ChildPath '\MSFT_xADCommon\MSFT_xADCommon.ps1'
-. $adCommonFunctions
 
 Export-ModuleMember -Function *-TargetResource

--- a/DSCResources/MSFT_xADGroup/MSFT_xADGroup.psm1
+++ b/DSCResources/MSFT_xADGroup/MSFT_xADGroup.psm1
@@ -133,7 +133,7 @@ function Get-TargetResource
     }
     catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException]
     {
-        Write-Verbose ($LocalizedData.GroupNotFound -f $GroupName)
+        Write-Verbose -Message ($LocalizedData.GroupNotFound -f $GroupName)
         $targetResource = @{
             GroupName = $GroupName
             GroupScope = $GroupScope
@@ -252,37 +252,37 @@ function Test-TargetResource
     $targetResourceInCompliance = $true
     if ($PSBoundParameters.ContainsKey('GroupScope') -and $targetResource.GroupScope -ne $GroupScope)
     {
-        Write-Verbose ($LocalizedData.NotDesiredPropertyState -f 'GroupScope', $GroupScope, $targetResource.GroupScope)
+        Write-Verbose -Message ($LocalizedData.NotDesiredPropertyState -f 'GroupScope', $GroupScope, $targetResource.GroupScope)
         $targetResourceInCompliance = $false
     }
     if ($PSBoundParameters.ContainsKey('Category') -and $targetResource.Category -ne $Category)
     {
-        Write-Verbose ($LocalizedData.NotDesiredPropertyState -f 'Category', $Category, $targetResource.Category)
+        Write-Verbose -Message ($LocalizedData.NotDesiredPropertyState -f 'Category', $Category, $targetResource.Category)
         $targetResourceInCompliance = $false
     }
     if ($Path -and ($targetResource.Path -ne $Path))
     {
-        Write-Verbose ($LocalizedData.NotDesiredPropertyState -f 'Path', $Path, $targetResource.Path)
+        Write-Verbose -Message ($LocalizedData.NotDesiredPropertyState -f 'Path', $Path, $targetResource.Path)
         $targetResourceInCompliance = $false
     }
     if ($Description -and ($targetResource.Description -ne $Description))
     {
-        Write-Verbose ($LocalizedData.NotDesiredPropertyState -f 'Description', $Description, $targetResource.Description)
+        Write-Verbose -Message ($LocalizedData.NotDesiredPropertyState -f 'Description', $Description, $targetResource.Description)
         $targetResourceInCompliance = $false
     }
     if ($DisplayName -and ($targetResource.DisplayName -ne $DisplayName))
     {
-        Write-Verbose ($LocalizedData.NotDesiredPropertyState -f 'DisplayName', $DisplayName, $targetResource.DisplayName)
+        Write-Verbose -Message ($LocalizedData.NotDesiredPropertyState -f 'DisplayName', $DisplayName, $targetResource.DisplayName)
         $targetResourceInCompliance = $false
     }
     if ($ManagedBy -and ($targetResource.ManagedBy -ne $ManagedBy))
     {
-        Write-Verbose ($LocalizedData.NotDesiredPropertyState -f 'ManagedBy', $ManagedBy, $targetResource.ManagedBy)
+        Write-Verbose -Message ($LocalizedData.NotDesiredPropertyState -f 'ManagedBy', $ManagedBy, $targetResource.ManagedBy)
         $targetResourceInCompliance = $false
     }
     if ($Notes -and ($targetResource.Notes -ne $Notes))
     {
-        Write-Verbose ($LocalizedData.NotDesiredPropertyState -f 'Notes', $Notes, $targetResource.Notes)
+        Write-Verbose -Message ($LocalizedData.NotDesiredPropertyState -f 'Notes', $Notes, $targetResource.Notes)
         $targetResourceInCompliance = $false
     }
     # Test group members match passed membership parameters
@@ -293,7 +293,7 @@ function Test-TargetResource
     }
     if ($targetResource.Ensure -ne $Ensure)
     {
-        Write-Verbose ($LocalizedData.NotDesiredPropertyState -f 'Ensure', $Ensure, $targetResource.Ensure)
+        Write-Verbose -Message ($LocalizedData.NotDesiredPropertyState -f 'Ensure', $Ensure, $targetResource.Ensure)
         $targetResourceInCompliance = $false
     }
     return $targetResourceInCompliance
@@ -394,43 +394,43 @@ function Set-TargetResource
             # Update existing group properties
             if ($PSBoundParameters.ContainsKey('Category') -and $Category -ne $adGroup.GroupCategory)
             {
-                Write-Verbose ($LocalizedData.UpdatingGroupProperty -f 'Category', $Category)
+                Write-Verbose -Message ($LocalizedData.UpdatingGroupProperty -f 'Category', $Category)
                 $setADGroupParams['GroupCategory'] = $Category
             }
             if ($PSBoundParameters.ContainsKey('GroupScope') -and $GroupScope -ne $adGroup.GroupScope)
             {
                 # Cannot change DomainLocal to Global or vice versa directly. Need to change them to a Universal group first!
                 Set-ADGroup -Identity $adGroup.DistinguishedName -GroupScope Universal
-                Write-Verbose ($LocalizedData.UpdatingGroupProperty -f 'GroupScope', $GroupScope)
+                Write-Verbose -Message ($LocalizedData.UpdatingGroupProperty -f 'GroupScope', $GroupScope)
                 $setADGroupParams['GroupScope'] = $GroupScope
             }
             if ($Description -and ($Description -ne $adGroup.Description))
             {
-                Write-Verbose ($LocalizedData.UpdatingGroupProperty -f 'Description', $Description)
+                Write-Verbose -Message ($LocalizedData.UpdatingGroupProperty -f 'Description', $Description)
                 $setADGroupParams['Description'] = $Description
             }
             if ($DisplayName -and ($DisplayName -ne $adGroup.DisplayName))
             {
-                Write-Verbose ($LocalizedData.UpdatingGroupProperty -f 'DisplayName', $DisplayName)
+                Write-Verbose -Message ($LocalizedData.UpdatingGroupProperty -f 'DisplayName', $DisplayName)
                 $setADGroupParams['DisplayName'] = $DisplayName
             }
             if ($ManagedBy -and ($ManagedBy -ne $adGroup.ManagedBy))
             {
-                Write-Verbose ($LocalizedData.UpdatingGroupProperty -f 'ManagedBy', $ManagedBy)
+                Write-Verbose -Message ($LocalizedData.UpdatingGroupProperty -f 'ManagedBy', $ManagedBy)
                 $setADGroupParams['ManagedBy'] = $ManagedBy
             }
             if ($Notes -and ($Notes -ne $adGroup.Info))
             {
-                Write-Verbose ($LocalizedData.UpdatingGroupProperty -f 'Notes', $Notes)
+                Write-Verbose -Message ($LocalizedData.UpdatingGroupProperty -f 'Notes', $Notes)
                 $setADGroupParams['Replace'] = @{ Info = $Notes }
             }
-            Write-Verbose ($LocalizedData.UpdatingGroup -f $GroupName)
+            Write-Verbose -Message ($LocalizedData.UpdatingGroup -f $GroupName)
             Set-ADGroup @setADGroupParams
 
             # Move group if the path is not correct
             if ($Path -and ($Path -ne (Get-ADObjectParentDN -DN $adGroup.DistinguishedName)))
             {
-                Write-Verbose ($LocalizedData.MovingGroup -f $GroupName, $Path)
+                Write-Verbose -Message ($LocalizedData.MovingGroup -f $GroupName, $Path)
                 $moveADObjectParams = $adGroupParams.Clone()
                 $moveADObjectParams['Identity'] = $adGroup.DistinguishedName
                 Move-ADObject @moveADObjectParams -TargetPath $Path
@@ -472,7 +472,7 @@ function Set-TargetResource
         elseif ($Ensure -eq 'Absent')
         {
             # Remove existing group
-            Write-Verbose ($LocalizedData.RemovingGroup -f $GroupName)
+            Write-Verbose -Message ($LocalizedData.RemovingGroup -f $GroupName)
             Remove-ADGroup @adGroupParams -Confirm:$false
         }
     }
@@ -481,8 +481,8 @@ function Set-TargetResource
         # The AD group doesn't exist
         if ($Ensure -eq 'Present')
         {
-            Write-Verbose ($LocalizedData.GroupNotFound -f $GroupName)
-            Write-Verbose ($LocalizedData.AddingGroup -f $GroupName)
+            Write-Verbose -Message ($LocalizedData.GroupNotFound -f $GroupName)
+            Write-Verbose -Message ($LocalizedData.AddingGroup -f $GroupName)
 
             $adGroupParams = Get-ADCommonParameters @PSBoundParameters -UseNameParameter
             if ($Description)
@@ -511,7 +511,7 @@ function Set-TargetResource
             if ($Notes)
             {
                 # Can't set the Notes field when creating the group
-                Write-Verbose ($LocalizedData.UpdatingGroupProperty -f 'Notes', $Notes)
+                Write-Verbose -Message ($LocalizedData.UpdatingGroupProperty -f 'Notes', $Notes)
                 $setADGroupParams = $adGroupParams.Clone()
                 $setADGroupParams['Identity'] = $adGroup.DistinguishedName
                 Set-ADGroup @setADGroupParams -Add @{ Info = $Notes }

--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ The xADServicePrincipalName DSC resource will manage service principal names.
     ([issue #194](https://github.com/PowerShell/xActiveDirectory/issues/194)).
   * Adding a Branches section to the README.md with Codecov badges for both
     master and dev branch ([issue #192](https://github.com/PowerShell/xActiveDirectory/issues/192)).
+  * xADGroup no longer resets GroupScope and Category to default values ([issue #183](https://github.com/PowerShell/xActiveDirectory/issues/183)).
 
 ### 2.18.0.0
 

--- a/Tests/Unit/MSFT_xADGroup.Tests.ps1
+++ b/Tests/Unit/MSFT_xADGroup.Tests.ps1
@@ -532,12 +532,12 @@ try
                 $fakeADUniversalGroup['GroupScope'] = 'Universal'
 
                 Mock -CommandName Get-ADGroup { return [PSCustomObject] $fakeADUniversalGroup }
-                Mock -CommandName Set-ADGroup { }
-                Mock -CommandName Add-ADGroupMember { }
+                Mock -CommandName Set-ADGroup
+                Mock -CommandName Add-ADGroupMember
 
-                Set-TargetResource @testUniversalPresentParams -Members @($fakeADUser1.SamAccountName, $fakeADUser2.SamAccountName);
+                Set-TargetResource @testUniversalPresentParams -Members @($fakeADUser1.SamAccountName, $fakeADUser2.SamAccountName)
 
-                Assert-MockCalled -CommandName Set-ADGroup -Times 0 -Scope It;
+                Assert-MockCalled -CommandName Set-ADGroup -Times 0 -Scope It
             }
 
             # tests for issue 183
@@ -548,12 +548,12 @@ try
                 $fakeADUniversalGroup['GroupCategory'] = 'Distribution'
 
                 Mock -CommandName Get-ADGroup { return [PSCustomObject] $fakeADUniversalGroup }
-                Mock -CommandName Set-ADGroup { }
-                Mock -CommandName Add-ADGroupMember { }
+                Mock -CommandName Set-ADGroup
+                Mock -CommandName Add-ADGroupMember
 
-                Set-TargetResource @testUniversalPresentParams -Members @($fakeADUser1.SamAccountName, $fakeADUser2.SamAccountName);
+                Set-TargetResource @testUniversalPresentParams -Members @($fakeADUser1.SamAccountName, $fakeADUser2.SamAccountName)
 
-                Assert-MockCalled -CommandName Set-ADGroup -Times 0 -Scope It;
+                Assert-MockCalled -CommandName Set-ADGroup -Times 0 -Scope It
             }
 
         }

--- a/Tests/Unit/MSFT_xADGroup.Tests.ps1
+++ b/Tests/Unit/MSFT_xADGroup.Tests.ps1
@@ -526,7 +526,7 @@ try
 
             # tests for issue 183
             It "Doesn't reset to 'Global' when not specifying a 'Scope' and updating group membership" {
-                $testUniversalPresentParams = $testUniversalPresentParams.Clone()
+                $testUniversalPresentParams = $testPresentParams.Clone()
                 $testUniversalPresentParams['Scope'] = 'Universal'
                 $fakeADUniversalGroup = $fakeADGroup.Clone()
                 $fakeADUniversalGroup['GroupScope'] = 'Universal'
@@ -542,7 +542,7 @@ try
 
             # tests for issue 183
             It "Doesn't reset to 'Security' when not specifying a 'Category' and updating group membership" {
-                $testUniversalPresentParams = $testUniversalPresentParams.Clone()
+                $testUniversalPresentParams = $testPresentParams.Clone()
                 $testUniversalPresentParams['Category'] = 'Distribution'
                 $fakeADUniversalGroup = $fakeADGroup.Clone()
                 $fakeADUniversalGroup['GroupCategory'] = 'Distribution'

--- a/Tests/Unit/MSFT_xADGroup.Tests.ps1
+++ b/Tests/Unit/MSFT_xADGroup.Tests.ps1
@@ -578,6 +578,10 @@ try
                 $fakeADUniversalGroup = $fakeADGroup.Clone()
                 $fakeADUniversalGroup['GroupCategory'] = 'Distribution'
 
+                Mock -CommandName Get-ADGroup { return [PSCustomObject] $fakeADUniversalGroup }
+                Mock -CommandName Set-ADGroup -ParameterFilter { $Identity -eq $fakeADUniversalGroup.Identity -and -not $PSBoundParameters.ContainsKey('GroupScope') }
+                Mock -CommandName Add-ADGroupMember
+
                 $universalGroupInCompliance = Test-TargetResource -GroupName $testUniversalPresentParams.GroupName -DisplayName $testUniversalPresentParams.DisplayName | Should Be $true
                 $universalGroupInCompliance | Should Be $true
             }

--- a/Tests/Unit/MSFT_xADGroup.Tests.ps1
+++ b/Tests/Unit/MSFT_xADGroup.Tests.ps1
@@ -582,7 +582,7 @@ try
                 Mock -CommandName Set-ADGroup -ParameterFilter { $Identity -eq $fakeADUniversalGroup.Identity -and -not $PSBoundParameters.ContainsKey('GroupScope') }
                 Mock -CommandName Add-ADGroupMember
 
-                $universalGroupInCompliance = Test-TargetResource -GroupName $testUniversalPresentParams.GroupName -DisplayName $testUniversalPresentParams.DisplayName | Should Be $true
+                $universalGroupInCompliance = Test-TargetResource -GroupName $testUniversalPresentParams.GroupName -DisplayName $testUniversalPresentParams.DisplayName
                 $universalGroupInCompliance | Should Be $true
             }
 

--- a/Tests/Unit/MSFT_xADGroup.Tests.ps1
+++ b/Tests/Unit/MSFT_xADGroup.Tests.ps1
@@ -532,12 +532,12 @@ try
                 $fakeADUniversalGroup['GroupScope'] = 'Universal'
 
                 Mock -CommandName Get-ADGroup { return [PSCustomObject] $fakeADUniversalGroup }
-                Mock -CommandName Set-ADGroup
+                Mock -CommandName Set-ADGroup -ParameterFilter { $Identity -eq $fakeADUniversalGroup.Identity -and -not $PSBoundParameters.ContainsKey('GroupScope') }
                 Mock -CommandName Add-ADGroupMember
 
                 Set-TargetResource -GroupName $testUniversalPresentParams.GroupName -Members @($fakeADUser1.SamAccountName, $fakeADUser2.SamAccountName)
 
-                Assert-MockCalled -CommandName Set-ADGroup -Times 0 -Scope It
+                Assert-MockCalled -CommandName Set-ADGroup -Times 1 -Scope It
             }
 
             # tests for issue 183
@@ -548,7 +548,7 @@ try
                 $fakeADUniversalGroup['GroupCategory'] = 'Distribution'
 
                 Mock -CommandName Get-ADGroup { return [PSCustomObject] $fakeADUniversalGroup }
-                Mock -CommandName Set-ADGroup
+                Mock -CommandName Set-ADGroup -ParameterFilter { $Identity -eq $fakeADUniversalGroup.Identity -and -not $PSBoundParameters.ContainsKey('GroupCategory') }
                 Mock -CommandName Add-ADGroupMember
 
                 Set-TargetResource -GroupName $testUniversalPresentParams.GroupName -Members @($fakeADUser1.SamAccountName, $fakeADUser2.SamAccountName)

--- a/Tests/Unit/MSFT_xADGroup.Tests.ps1
+++ b/Tests/Unit/MSFT_xADGroup.Tests.ps1
@@ -553,7 +553,7 @@ try
 
                 Set-TargetResource -GroupName $testUniversalPresentParams.GroupName -Members @($fakeADUser1.SamAccountName, $fakeADUser2.SamAccountName)
 
-                Assert-MockCalled -CommandName Set-ADGroup -Times 0 -Scope It
+                Assert-MockCalled -CommandName Set-ADGroup -Times 1 -Scope It
             }
 
         }

--- a/Tests/Unit/MSFT_xADGroup.Tests.ps1
+++ b/Tests/Unit/MSFT_xADGroup.Tests.ps1
@@ -535,7 +535,7 @@ try
                 Mock -CommandName Set-ADGroup
                 Mock -CommandName Add-ADGroupMember
 
-                Set-TargetResource @testUniversalPresentParams -Members @($fakeADUser1.SamAccountName, $fakeADUser2.SamAccountName)
+                Set-TargetResource -GroupName $testUniversalPresentParams.GroupName -Members @($fakeADUser1.SamAccountName, $fakeADUser2.SamAccountName)
 
                 Assert-MockCalled -CommandName Set-ADGroup -Times 0 -Scope It
             }
@@ -551,7 +551,7 @@ try
                 Mock -CommandName Set-ADGroup
                 Mock -CommandName Add-ADGroupMember
 
-                Set-TargetResource @testUniversalPresentParams -Members @($fakeADUser1.SamAccountName, $fakeADUser2.SamAccountName)
+                Set-TargetResource -GroupName $testUniversalPresentParams.GroupName -Members @($fakeADUser1.SamAccountName, $fakeADUser2.SamAccountName)
 
                 Assert-MockCalled -CommandName Set-ADGroup -Times 0 -Scope It
             }

--- a/Tests/Unit/MSFT_xADGroup.Tests.ps1
+++ b/Tests/Unit/MSFT_xADGroup.Tests.ps1
@@ -556,6 +556,32 @@ try
                 Assert-MockCalled -CommandName Set-ADGroup -Times 1 -Scope It
             }
 
+            # tests for issue 183
+            It "Doesn't reset to 'Global' when not specifying a 'Scope' and testing display name" {
+                $testUniversalPresentParams = $testPresentParams.Clone()
+                $testUniversalPresentParams['GroupScope'] = 'Universal'
+                $fakeADUniversalGroup = $fakeADGroup.Clone()
+                $fakeADUniversalGroup['GroupScope'] = 'Universal'
+
+                Mock -CommandName Get-ADGroup { return [PSCustomObject] $fakeADUniversalGroup }
+                Mock -CommandName Set-ADGroup -ParameterFilter { $Identity -eq $fakeADUniversalGroup.Identity -and -not $PSBoundParameters.ContainsKey('GroupScope') }
+                Mock -CommandName Add-ADGroupMember
+
+                $universalGroupInCompliance = Test-TargetResource -GroupName $testUniversalPresentParams.GroupName -DisplayName $testUniversalPresentParams.DisplayName
+                $universalGroupInCompliance | Should Be $true
+            }
+
+            # tests for issue 183
+            It "Doesn't reset to 'Security' when not specifying a 'Category' and testing display name" {
+                $testUniversalPresentParams = $testPresentParams.Clone()
+                $testUniversalPresentParams['Category'] = 'Distribution'
+                $fakeADUniversalGroup = $fakeADGroup.Clone()
+                $fakeADUniversalGroup['GroupCategory'] = 'Distribution'
+
+                $universalGroupInCompliance = Test-TargetResource -GroupName $testUniversalPresentParams.GroupName -DisplayName $testUniversalPresentParams.DisplayName | Should Be $true
+                $universalGroupInCompliance | Should Be $true
+            }
+
         }
         #end region
 

--- a/Tests/Unit/MSFT_xADGroup.Tests.ps1
+++ b/Tests/Unit/MSFT_xADGroup.Tests.ps1
@@ -523,6 +523,39 @@ try
                 Assert-MockCalled Move-ADObject -ParameterFilter { $Credential -eq $testCredentials } -Scope It;
             }
 
+
+            # tests for issue 183
+            It "Doesn't reset to 'Global' when not specifying a 'Scope' and updating group membership" {
+                $testUniversalPresentParams = $testUniversalPresentParams.Clone()
+                $testUniversalPresentParams['Scope'] = 'Universal'
+                $fakeADUniversalGroup = $fakeADGroup.Clone()
+                $fakeADUniversalGroup['GroupScope'] = 'Universal'
+
+                Mock -CommandName Get-ADGroup { return [PSCustomObject] $fakeADUniversalGroup }
+                Mock -CommandName Set-ADGroup { }
+                Mock -CommandName Add-ADGroupMember { }
+
+                Set-TargetResource @testUniversalPresentParams -Members @($fakeADUser1.SamAccountName, $fakeADUser2.SamAccountName);
+
+                Assert-MockCalled -CommandName Set-ADGroup -Times 0 -Scope It;
+            }
+
+            # tests for issue 183
+            It "Doesn't reset to 'Security' when not specifying a 'Category' and updating group membership" {
+                $testUniversalPresentParams = $testUniversalPresentParams.Clone()
+                $testUniversalPresentParams['Category'] = 'Distribution'
+                $fakeADUniversalGroup = $fakeADGroup.Clone()
+                $fakeADUniversalGroup['GroupCategory'] = 'Distribution'
+
+                Mock -CommandName Get-ADGroup { return [PSCustomObject] $fakeADUniversalGroup }
+                Mock -CommandName Set-ADGroup { }
+                Mock -CommandName Add-ADGroupMember { }
+
+                Set-TargetResource @testUniversalPresentParams -Members @($fakeADUser1.SamAccountName, $fakeADUser2.SamAccountName);
+
+                Assert-MockCalled -CommandName Set-ADGroup -Times 0 -Scope It;
+            }
+
         }
         #end region
 

--- a/Tests/Unit/MSFT_xADGroup.Tests.ps1
+++ b/Tests/Unit/MSFT_xADGroup.Tests.ps1
@@ -527,7 +527,7 @@ try
             # tests for issue 183
             It "Doesn't reset to 'Global' when not specifying a 'Scope' and updating group membership" {
                 $testUniversalPresentParams = $testPresentParams.Clone()
-                $testUniversalPresentParams['Scope'] = 'Universal'
+                $testUniversalPresentParams['GroupScope'] = 'Universal'
                 $fakeADUniversalGroup = $fakeADGroup.Clone()
                 $fakeADUniversalGroup['GroupScope'] = 'Universal'
 


### PR DESCRIPTION
Changes to xADGroup to resolve Issue #183. Since the parameters had a default value I had to add checking to see if the parameter was actually bound before setting it. This was true for the GroupScope and Category parameters.

While I was in there I cleaned up a few formatting issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xactivedirectory/197)
<!-- Reviewable:end -->
