### PR TITLE
Implement ad object restore

### DIFF
--- a/DSCResources/MSFT_xADCommon/MSFT_xADCommon.psm1
+++ b/DSCResources/MSFT_xADCommon/MSFT_xADCommon.psm1
@@ -9,6 +9,7 @@ data localizedString
         IncludeAndExcludeConflictError = The member '{0}' is included in both '{1}' and '{2}' parameter values. The same member must not be included in both '{1}' and '{2}' parameter values.
         IncludeAndExcludeAreEmptyError = The '{0}' and '{1}' parameters are either both null or empty.  At least one member must be specified in one of these parameters.
         ModeConversionError            = Converted mode {0} is not a {1}.
+        RestoreFailed                  = Restoring {0} ({1}) failed. {2}.
 
         CheckingMembers                = Checking for '{0}' members.
         MembershipCountMismatch        = Membership count is not correct. Expected '{0}' members, actual '{1}' members.
@@ -18,6 +19,9 @@ data localizedString
         MembershipNotDesiredState      = Membership is NOT in the desired state.
         CheckingDomain                 = Checking for domain '{0}'.
         CheckingSite                   = Checking for site '{0}'.
+        FindInRecycleBin               = Finding objects in recycle bin matching filter {0}.
+        FoundRestoreTarget             = Found object {0} ({1}) in recycle bin as {2}. Attempting to restore the object.
+        RestoreOk                      = Successfully restored object {0} ({1}).
 '@
 }
 
@@ -698,4 +702,64 @@ function ConvertTo-DeploymentDomainMode
     }
 
     return $convertedMode
+}
+
+function Restore-ADCommonObject
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [Alias('UserName','GroupName','ComputerName')]
+        [System.String]
+        $Identity,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Computer','OrganizationalUnit','User','Group')]
+        [System.String]
+        $ObjectClass,
+
+        [Parameter()]
+        [ValidateNotNull()]
+        [Alias('DomainAdministratorCredential')]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.CredentialAttribute()]
+        $Credential,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [Alias('DomainController')]
+        [System.String]
+        $Server,
+
+        [Parameter()]
+        [switch]
+        $PassThru
+    )
+
+    $restoreFilter = 'msDS-LastKnownRDN -eq "{0}" -and objectClass -eq "{1}" -and isDeleted -eq $true' -f $Identity, $ObjectClass
+    Write-Verbose -Message ($localizedString.FindInRecycleBin -f $restoreFilter)
+
+    # Using IsDeleted and IncludeDeletedObjects will mean that the cmdlet does not throw
+    # any more, and simply returns $null instead
+    $restoreParams = Get-ADCommonParameters @PSBoundParameters
+    $restoreParams.Remove('Identity')
+    $restorableObject = Get-ADObject -Filter $restoreFilter -IncludeDeletedObjects @restoreParams
+
+    if ($restorableObject)
+    {
+        Write-Verbose -Message ($localizedString.FoundRestoreTarget -f $Identity, $ObjectClass, $restorableObject.DistinguishedName)
+
+        try
+        {
+            $restorableObject | Restore-ADObject @restoreParams -ErrorAction Stop -PassThru:$PassThru
+            Write-Verbose -Message ($localizedString.RestoreOk -f $Identity, $ObjectClass)
+        }
+        catch [Microsoft.ActiveDirectory.Management.ADException]
+        {
+            # After Get-TargetResource is through, only one error can occur here: Object parent does not exist
+            ThrowInvalidOperationError -ErrorId "$($Identity)_RestoreFailed" -ErrorMessage ($localizedString.RestoreFailed -f $Identity, $ObjectClass, $_.Exception.Message)
+        }
+    }
 }

--- a/DSCResources/MSFT_xADCommon/MSFT_xADCommon.psm1
+++ b/DSCResources/MSFT_xADCommon/MSFT_xADCommon.psm1
@@ -746,9 +746,6 @@ function Restore-ADCommonObject
     $getAdObjectParams.Remove('Identity')
     $getAdObjectParams['Filter'] = $restoreFilter
     $getAdObjectParams['IncludeDeletedObjects'] = $true
-    $restoreParams = $commonParams.Clone()
-    $restoreParams['PassThru'] = $true
-    $restoreParams['ErrorAction'] = 'Stop'
 
     $restorableObject = Get-ADObject @getAdObjectParams
     $restoredObject = $null
@@ -759,6 +756,9 @@ function Restore-ADCommonObject
 
         try
         {
+            $restoreParams = $commonParams.Clone()
+            $restoreParams['PassThru'] = $true
+            $restoreParams['ErrorAction'] = 'Stop'
             $restoreParams['Identity'] = $restorableObject.DistinguishedName
             $restoredObject = Restore-ADObject @restoreParams
             Write-Verbose -Message ($localizedString.RecycleBinRestoreSuccessful -f $Identity, $ObjectClass)

--- a/DSCResources/MSFT_xADComputer/MSFT_xADComputer.schema.mof
+++ b/DSCResources/MSFT_xADComputer/MSFT_xADComputer.schema.mof
@@ -15,6 +15,7 @@ class MSFT_xADComputer : OMI_BaseResource
     [Write, Description("Specifies the user account credentials to use to perform the task"), EmbeddedInstance("MSFT_Credential")] String DomainAdministratorCredential;
     [Write, Description("Specifies the full path to the Offline Domain Join Request file to create.")] String RequestFile;
     [Write, ValueMap{"Present", "Absent"},Values{"Present", "Absent"}] String Ensure;
+    [Write, Description("Indicates whether or not objects should be restored from recycle bin instead of recreating them")] Boolean RestoreFromRecycleBin;
     [Read, Description("Returns the X.500 path of the computer object")] String DistinguishedName;
     [Read, Description("Returns the security identifier of the computer object")] String SID;
 };

--- a/DSCResources/MSFT_xADComputer/MSFT_xADComputer.schema.mof
+++ b/DSCResources/MSFT_xADComputer/MSFT_xADComputer.schema.mof
@@ -15,7 +15,7 @@ class MSFT_xADComputer : OMI_BaseResource
     [Write, Description("Specifies the user account credentials to use to perform the task"), EmbeddedInstance("MSFT_Credential")] String DomainAdministratorCredential;
     [Write, Description("Specifies the full path to the Offline Domain Join Request file to create.")] String RequestFile;
     [Write, ValueMap{"Present", "Absent"},Values{"Present", "Absent"}] String Ensure;
-    [Write, Description("Indicates whether or not objects should be restored from recycle bin instead of recreating them")] Boolean RestoreFromRecycleBin;
+    [Write, Description("Indicates whether or not the computer object should first tried to be restored from the recycle bin before creating a new computer object.")] Boolean RestoreFromRecycleBin;
     [Read, Description("Returns the X.500 path of the computer object")] String DistinguishedName;
     [Read, Description("Returns the security identifier of the computer object")] String SID;
 };

--- a/DSCResources/MSFT_xADComputer/en-US/MSFT_xADComputer.psd1
+++ b/DSCResources/MSFT_xADComputer/en-US/MSFT_xADComputer.psd1
@@ -18,7 +18,7 @@ ConvertFrom-StringData @'
     RemovingADComputerProperty        = Removing computer property '{0}' with '{1}'.
     MovingADComputer                  = Moving computer from '{0}' to '{1}'.
     RenamingADComputer                = Renaming computer from '{0}' to '{1}'.
-    RestoringADComputer               = Attempting to restore computer {0} from recycle bin
+    RestoringADComputer               = Attempting to restore the computer object {0} from recycle bin.
 
     ODJRequestStartMessage=Attempting to create the ODJ request file '{2}' for computer '{1}' in Domain '{0}'.
     ODJRequestCompleteMessage=The ODJ request file '{2}' for computer '{1}' in Domain '{0}' has been provisioned successfully.

--- a/DSCResources/MSFT_xADComputer/en-US/MSFT_xADComputer.psd1
+++ b/DSCResources/MSFT_xADComputer/en-US/MSFT_xADComputer.psd1
@@ -18,6 +18,7 @@ ConvertFrom-StringData @'
     RemovingADComputerProperty        = Removing computer property '{0}' with '{1}'.
     MovingADComputer                  = Moving computer from '{0}' to '{1}'.
     RenamingADComputer                = Renaming computer from '{0}' to '{1}'.
+    RestoringADComputer               = Attempting to restore computer {0} from recycle bin
 
     ODJRequestStartMessage=Attempting to create the ODJ request file '{2}' for computer '{1}' in Domain '{0}'.
     ODJRequestCompleteMessage=The ODJ request file '{2}' for computer '{1}' in Domain '{0}' has been provisioned successfully.

--- a/DSCResources/MSFT_xADGroup/MSFT_xADGroup.psm1
+++ b/DSCResources/MSFT_xADGroup/MSFT_xADGroup.psm1
@@ -19,7 +19,7 @@ data LocalizedData
         UpdatingGroup                  = Updating AD Group '{0}'
         RemovingGroup                  = Removing AD Group '{0}'
         MovingGroup                    = Moving AD Group '{0}' to '{1}'
-        RestoringGroup                 = Attempting to restore group {0} from recycle bin
+        RestoringGroup                 = Attempting to restore the group {0} from recycle bin.
         GroupNotFound                  = AD Group '{0}' was not found
         NotDesiredPropertyState        = AD Group '{0}' is not correct. Expected '{1}', actual '{2}'
         UpdatingGroupProperty          = Updating AD Group property '{0}' to '{1}'
@@ -518,13 +518,16 @@ function Set-TargetResource
             {
                 $adGroupParams['Path'] = $Path
             }
-            # Create group
-            # Try to restore account first if it exists
+            
+            <#
+                Create group
+                Try to restore account first if it exists
+            #>
             if($RestoreFromRecycleBin)
             {
                 Write-Verbose -Message ($LocalizedData.RestoringGroup -f $GroupName)
                 $restoreParams = Get-ADCommonParameters @PSBoundParameters
-                $adGroup = Restore-ADCommonObject @restoreParams -ObjectClass Group -ErrorAction Stop -PassThru
+                $adGroup = Restore-ADCommonObject @restoreParams -ObjectClass Group -ErrorAction Stop
             }
 
             if (-not $adGroup)

--- a/DSCResources/MSFT_xADGroup/MSFT_xADGroup.schema.mof
+++ b/DSCResources/MSFT_xADGroup/MSFT_xADGroup.schema.mof
@@ -16,4 +16,5 @@ class MSFT_xADGroup : OMI_BaseResource
     [Write, Description("Active Directory attribute used to perform membership operations"), ValueMap{"SamAccountName","DistinguishedName","ObjectGUID","SID"}, Values{"SamAccountName","DistinguishedName","ObjectGUID","SID"}] String MembershipAttribute;
     [Write, Description("Active Directory managed by attribute specified as a DistinguishedName")] String ManagedBy;
     [Write, Description("Active Directory group notes field")] String Notes;
+    [Write, Description("Indicates whether or not objects should be restored from recycle bin instead of recreating them")] Boolean RestoreFromRecycleBin;
 };

--- a/DSCResources/MSFT_xADGroup/MSFT_xADGroup.schema.mof
+++ b/DSCResources/MSFT_xADGroup/MSFT_xADGroup.schema.mof
@@ -16,5 +16,5 @@ class MSFT_xADGroup : OMI_BaseResource
     [Write, Description("Active Directory attribute used to perform membership operations"), ValueMap{"SamAccountName","DistinguishedName","ObjectGUID","SID"}, Values{"SamAccountName","DistinguishedName","ObjectGUID","SID"}] String MembershipAttribute;
     [Write, Description("Active Directory managed by attribute specified as a DistinguishedName")] String ManagedBy;
     [Write, Description("Active Directory group notes field")] String Notes;
-    [Write, Description("Indicates whether or not the group object should first tried to be restored from the recycle bin before creating a new computer object.")] Boolean RestoreFromRecycleBin;
+    [Write, Description("Indicates whether or not the group object should first tried to be restored from the recycle bin before creating a new group object.")] Boolean RestoreFromRecycleBin;
 };

--- a/DSCResources/MSFT_xADGroup/MSFT_xADGroup.schema.mof
+++ b/DSCResources/MSFT_xADGroup/MSFT_xADGroup.schema.mof
@@ -16,5 +16,5 @@ class MSFT_xADGroup : OMI_BaseResource
     [Write, Description("Active Directory attribute used to perform membership operations"), ValueMap{"SamAccountName","DistinguishedName","ObjectGUID","SID"}, Values{"SamAccountName","DistinguishedName","ObjectGUID","SID"}] String MembershipAttribute;
     [Write, Description("Active Directory managed by attribute specified as a DistinguishedName")] String ManagedBy;
     [Write, Description("Active Directory group notes field")] String Notes;
-    [Write, Description("Indicates whether or not objects should be restored from recycle bin instead of recreating them")] Boolean RestoreFromRecycleBin;
+    [Write, Description("Indicates whether or not the group object should first tried to be restored from the recycle bin before creating a new computer object.")] Boolean RestoreFromRecycleBin;
 };

--- a/DSCResources/MSFT_xADOrganizationalUnit/MSFT_xADOrganizationalUnit.psm1
+++ b/DSCResources/MSFT_xADOrganizationalUnit/MSFT_xADOrganizationalUnit.psm1
@@ -9,16 +9,16 @@ data LocalizedData
 {
     # culture="en-US"
     ConvertFrom-StringData @'
-        RoleNotFoundError        = Please ensure that the PowerShell module for role '{0}' is installed
+        RoleNotFoundError        = Please ensure that the PowerShell module for role '{0}' is installed.
         RetrievingOU             = Retrieving OU '{0}'.
-        UpdatingOU               = Updating OU '{0}'
-        DeletingOU               = Deleting OU '{0}'
-        CreatingOU               = Creating OU '{0}'
-        RestoringOU              = Attempting to restore OU {0} from recycle bin
-        OUInDesiredState         = OU '{0}' exists and is in the desired state
-        OUNotInDesiredState      = OU '{0}' exists but is not in the desired state
-        OUExistsButShouldNot     = OU '{0}' exists when it should not exist
-        OUDoesNotExistButShould  = OU '{0}' does not exist when it should exist
+        UpdatingOU               = Updating OU '{0}'.
+        DeletingOU               = Deleting OU '{0}'.
+        CreatingOU               = Creating OU '{0}'.
+        RestoringOU              = Attempting to restore the organizational unit object {0} from the recycle bin.
+        OUInDesiredState         = OU '{0}' exists and is in the desired state.
+        OUNotInDesiredState      = OU '{0}' exists but is not in the desired state.
+        OUExistsButShouldNot     = OU '{0}' exists when it should not exist.
+        OUDoesNotExistButShould  = OU '{0}' does not exist when it should exist.
 '@
 }
 
@@ -78,7 +78,8 @@ function Test-TargetResource
         [System.String] $Description = '',
 
         [ValidateNotNull()]
-        [System.Boolean] $RestoreFromRecycleBin
+        [System.Boolean]
+        $RestoreFromRecycleBin
     )
 
     $targetResource = Get-TargetResource -Name $Name -Path $Path
@@ -161,7 +162,8 @@ function Set-TargetResource
         [System.String] $Description = '',
 
         [ValidateNotNull()]
-        [System.Boolean] $RestoreFromRecycleBin
+        [System.Boolean]
+        $RestoreFromRecycleBin
     )
 
     Assert-Module -ModuleName 'ActiveDirectory';
@@ -212,39 +214,40 @@ function Set-TargetResource
 
         return # return from Set method to make it easier to test for a succesful restore
     }
-    elseif ($RestoreFromRecycleBin)
+    else
     {
-        Write-Verbose -Message ($LocalizedData.RestoringOu -f $Name)
-        $restoreParams = @{
-            Identity    = $Name
-            ObjectClass = 'OrganizationalUnit'
-            ErrorAction = 'Stop'
-            PassThru    = $true
-        }
-
-        if ($Credential)
+        if  ($RestoreFromRecycleBin)
         {
-            $restoreParams['Credential'] = $Credential
+            Write-Verbose -Message ($LocalizedData.RestoringOu -f $Name)
+            $restoreParams = @{
+                Identity    = $Name
+                ObjectClass = 'OrganizationalUnit'
+                ErrorAction = 'Stop'
+            }
+
+            if ($Credential)
+            {
+                $restoreParams['Credential'] = $Credential
+            }
+
+            $restoreSuccessful = Restore-ADCommonObject @restoreParams
         }
 
-        $restoreSuccessful = Restore-ADCommonObject @restoreParams
-    }
-    
-    if (-not $RestoreFromRecycleBin -or ($RestoreFromRecycleBin -and -not $restoreSuccessful))
-    {
-        Write-Verbose ($LocalizedData.CreatingOU -f $targetResource.Name)
-        $newADOrganizationalUnitParams = @{
-            Name = $Name
-            Path = $Path
-            Description = $Description
-            ProtectedFromAccidentalDeletion = $ProtectedFromAccidentalDeletion
+        if (-not $RestoreFromRecycleBin -or ($RestoreFromRecycleBin -and -not $restoreSuccessful))
+        {
+            Write-Verbose ($LocalizedData.CreatingOU -f $targetResource.Name)
+            $newADOrganizationalUnitParams = @{
+                Name = $Name
+                Path = $Path
+                Description = $Description
+                ProtectedFromAccidentalDeletion = $ProtectedFromAccidentalDeletion
+            }
+            if ($Credential) {
+                $newADOrganizationalUnitParams['Credential'] = $Credential
+            }
+            New-ADOrganizationalUnit @newADOrganizationalUnitParams
         }
-        if ($Credential) {
-            $newADOrganizationalUnitParams['Credential'] = $Credential
-        }
-        New-ADOrganizationalUnit @newADOrganizationalUnitParams
     }
-
 } #end function Set-TargetResource
 
 Export-ModuleMember -Function *-TargetResource

--- a/DSCResources/MSFT_xADOrganizationalUnit/MSFT_xADOrganizationalUnit.psm1
+++ b/DSCResources/MSFT_xADOrganizationalUnit/MSFT_xADOrganizationalUnit.psm1
@@ -209,14 +209,17 @@ function Set-TargetResource
             }
             Remove-ADOrganizationalUnit @removeADOrganizationalUnitParams
         }
+
+        return # return from Set method to make it easier to test for a succesful restore
     }
     elseif ($RestoreFromRecycleBin)
     {
         Write-Verbose -Message ($LocalizedData.RestoringOu -f $Name)
         $restoreParams = @{
-            Identity = $Name
+            Identity    = $Name
             ObjectClass = 'OrganizationalUnit'
             ErrorAction = 'Stop'
+            PassThru    = $true
         }
 
         if ($Credential)
@@ -224,9 +227,10 @@ function Set-TargetResource
             $restoreParams['Credential'] = $Credential
         }
 
-        Restore-ADCommonObject @restoreParams
+        $restoreSuccessful = Restore-ADCommonObject @restoreParams
     }
-    else
+    
+    if (-not $RestoreFromRecycleBin -or ($RestoreFromRecycleBin -and -not $restoreSuccessful))
     {
         Write-Verbose ($LocalizedData.CreatingOU -f $targetResource.Name)
         $newADOrganizationalUnitParams = @{

--- a/DSCResources/MSFT_xADOrganizationalUnit/MSFT_xADOrganizationalUnit.schema.mof
+++ b/DSCResources/MSFT_xADOrganizationalUnit/MSFT_xADOrganizationalUnit.schema.mof
@@ -8,5 +8,6 @@ class MSFT_xADOrganizationalUnit : OMI_BaseResource
     [Write, EmbeddedInstance("MSFT_Credential"),Description("The credential to be used to perform the operation on Active Directory")] string Credential;
     [Write, Description("Defaults to True")] boolean ProtectedFromAccidentalDeletion;
     [Write, Description("The description of the OU")] string Description;
+    [Write, Description("Indicates whether or not objects should be restored from recycle bin instead of recreating them")] Boolean RestoreFromRecycleBin;
 };
 

--- a/DSCResources/MSFT_xADOrganizationalUnit/MSFT_xADOrganizationalUnit.schema.mof
+++ b/DSCResources/MSFT_xADOrganizationalUnit/MSFT_xADOrganizationalUnit.schema.mof
@@ -8,6 +8,6 @@ class MSFT_xADOrganizationalUnit : OMI_BaseResource
     [Write, EmbeddedInstance("MSFT_Credential"),Description("The credential to be used to perform the operation on Active Directory")] string Credential;
     [Write, Description("Defaults to True")] boolean ProtectedFromAccidentalDeletion;
     [Write, Description("The description of the OU")] string Description;
-    [Write, Description("Indicates whether or not the organizational unit should first tried to be restored from the recycle bin before creating a new computer object.")] Boolean RestoreFromRecycleBin;
+    [Write, Description("Indicates whether or not the organizational unit should first tried to be restored from the recycle bin before creating a new organizational unit.")] Boolean RestoreFromRecycleBin;
 };
 

--- a/DSCResources/MSFT_xADOrganizationalUnit/MSFT_xADOrganizationalUnit.schema.mof
+++ b/DSCResources/MSFT_xADOrganizationalUnit/MSFT_xADOrganizationalUnit.schema.mof
@@ -8,6 +8,6 @@ class MSFT_xADOrganizationalUnit : OMI_BaseResource
     [Write, EmbeddedInstance("MSFT_Credential"),Description("The credential to be used to perform the operation on Active Directory")] string Credential;
     [Write, Description("Defaults to True")] boolean ProtectedFromAccidentalDeletion;
     [Write, Description("The description of the OU")] string Description;
-    [Write, Description("Indicates whether or not objects should be restored from recycle bin instead of recreating them")] Boolean RestoreFromRecycleBin;
+    [Write, Description("Indicates whether or not the organizational unit should first tried to be restored from the recycle bin before creating a new computer object.")] Boolean RestoreFromRecycleBin;
 };
 

--- a/DSCResources/MSFT_xADUser/MSFT_xADUser.psm1
+++ b/DSCResources/MSFT_xADUser/MSFT_xADUser.psm1
@@ -268,7 +268,7 @@ function Get-TargetResource
         [ValidateSet('Default','Negotiate')]
         [System.String] $PasswordAuthentication = 'Default',
 
-        ## Indicates whether or not objects should be restored from recycle bin instead of recreating them
+        ## Indicates whether or not the user object should first tried to be restored from the recycle bin before creating a new computer object.
         [ValidateNotNull()]
         [System.Boolean] $RestoreFromRecycleBin
     )
@@ -533,7 +533,7 @@ function Test-TargetResource
         [ValidateSet('Default','Negotiate')]
         [System.String] $PasswordAuthentication = 'Default',
 
-        ## Indicates whether or not objects should be restored from recycle bin instead of recreating them
+        ## Indicates whether or not the computer object should first tried to be restored from the recycle bin before creating a new computer object.
         [ValidateNotNull()]
         [System.Boolean] $RestoreFromRecycleBin
     )
@@ -786,7 +786,7 @@ function Set-TargetResource
         [ValidateSet('Default','Negotiate')]
         [System.String] $PasswordAuthentication = 'Default',
 
-        ## Indicates whether or not objects should be restored from recycle bin instead of recreating them
+        ## Indicates whether or not the computer object should first tried to be restored from the recycle bin before creating a new computer object.
         [ValidateNotNull()]
         [System.Boolean] $RestoreFromRecycleBin
     )

--- a/DSCResources/MSFT_xADUser/MSFT_xADUser.psm1
+++ b/DSCResources/MSFT_xADUser/MSFT_xADUser.psm1
@@ -1,7 +1,7 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUserNameAndPassWordParams', '')]
 param()
 
-## Import the common AD functions
+# Import the common AD functions
 $adCommonFunctions = Join-Path `
     -Path (Split-Path -Path $PSScriptRoot -Parent) `
     -ChildPath '\MSFT_xADCommon\MSFT_xADCommon.psm1'
@@ -31,12 +31,12 @@ data LocalizedData
         RemovingADUserProperty         = Removing user property '{0}' with '{1}'.
         MovingADUser                   = Moving user from '{0}' to '{1}'.
         RenamingADUser                 = Renaming user from '{0}' to '{1}'.
-        RestoringUser                  = Attempting to restore user {0} from recycle bin
+        RestoringUser                  = Attempting to restore the user object {0} from the recycle bin.
 '@
 }
 
-## Create a property map that maps the DSC resource parameters to the
-## Active Directory user attributes.
+# Create a property map that maps the DSC resource parameters to the
+# Active Directory user attributes.
 $adPropertyMap = @(
     @{ Parameter = 'CommonName'; ADProperty = 'cn'; }
     @{ Parameter = 'UserPrincipalName'; }
@@ -84,7 +84,7 @@ function Get-TargetResource
     [OutputType([System.Collections.Hashtable])]
     param
     (
-        ## Name of the domain where the user account is located (only used if password is managed)
+        # Name of the domain where the user account is located (only used if password is managed)
         [Parameter(Mandatory)]
         [System.String] $DomainName,
 
@@ -92,185 +92,186 @@ function Get-TargetResource
         [Parameter(Mandatory)]
         [System.String] $UserName,
 
-        ## Specifies a new password value for an account
+        # Specifies a new password value for an account
         [ValidateNotNull()]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.CredentialAttribute()]
         $Password,
 
-        ## Specifies whether the user account is created or deleted
+        # Specifies whether the user account is created or deleted
         [ValidateSet('Present', 'Absent')]
         [System.String] $Ensure = 'Present',
 
-        ## Specifies the common nane assigned to the user account (ldapDisplayName 'cn')
+        # Specifies the common nane assigned to the user account (ldapDisplayName 'cn')
         [ValidateNotNull()]
         [System.String] $CommonName = $UserName,
 
-        ## Specifies the UPN assigned to the user account (ldapDisplayName 'userPrincipalName')
+        # Specifies the UPN assigned to the user account (ldapDisplayName 'userPrincipalName')
         [ValidateNotNull()]
         [System.String] $UserPrincipalName,
 
-        ## Specifies the display name of the object (ldapDisplayName 'displayName')
+        # Specifies the display name of the object (ldapDisplayName 'displayName')
         [ValidateNotNull()]
         [System.String] $DisplayName,
 
-        ## Specifies the X.500 path of the Organizational Unit (OU) or container where the new object is created
+        # Specifies the X.500 path of the Organizational Unit (OU) or container where the new object is created
         [ValidateNotNull()]
         [System.String] $Path,
 
-        ## Specifies the user's given name (ldapDisplayName 'givenName')
+        # Specifies the user's given name (ldapDisplayName 'givenName')
         [ValidateNotNull()]
         [System.String] $GivenName,
 
-        ## Specifies the initials that represent part of a user's name (ldapDisplayName 'initials')
+        # Specifies the initials that represent part of a user's name (ldapDisplayName 'initials')
         [ValidateNotNull()]
         [System.String] $Initials,
 
-        ## Specifies the user's last name or surname (ldapDisplayName 'sn')
+        # Specifies the user's last name or surname (ldapDisplayName 'sn')
         [ValidateNotNull()]
         [System.String] $Surname,
 
-        ## Specifies a description of the object (ldapDisplayName 'description')
+        # Specifies a description of the object (ldapDisplayName 'description')
         [ValidateNotNull()]
         [System.String] $Description,
 
-        ## Specifies the user's street address (ldapDisplayName 'streetAddress')
+        # Specifies the user's street address (ldapDisplayName 'streetAddress')
         [ValidateNotNull()]
         [System.String] $StreetAddress,
 
-        ## Specifies the user's post office box number (ldapDisplayName 'postOfficeBox')
+        # Specifies the user's post office box number (ldapDisplayName 'postOfficeBox')
         [ValidateNotNull()]
         [System.String] $POBox,
 
-        ## Specifies the user's town or city (ldapDisplayName 'l')
+        # Specifies the user's town or city (ldapDisplayName 'l')
         [ValidateNotNull()]
         [System.String] $City,
 
-        ## Specifies the user's or Organizational Unit's state or province (ldapDisplayName 'st')
+        # Specifies the user's or Organizational Unit's state or province (ldapDisplayName 'st')
         [ValidateNotNull()]
         [System.String] $State,
 
-        ## Specifies the user's postal code or zip code (ldapDisplayName 'postalCode')
+        # Specifies the user's postal code or zip code (ldapDisplayName 'postalCode')
         [ValidateNotNull()]
         [System.String] $PostalCode,
 
-        ## Specifies the country or region code for the user's language of choice (ldapDisplayName 'c')
+        # Specifies the country or region code for the user's language of choice (ldapDisplayName 'c')
         [ValidateNotNull()]
         [System.String] $Country,
 
-        ## Specifies the user's department (ldapDisplayName 'department')
+        # Specifies the user's department (ldapDisplayName 'department')
         [ValidateNotNull()]
         [System.String] $Department,
 
-        ## Specifies the user's division (ldapDisplayName 'division')
+        # Specifies the user's division (ldapDisplayName 'division')
         [ValidateNotNull()]
         [System.String] $Division,
 
-        ## Specifies the user's company (ldapDisplayName 'company')
+        # Specifies the user's company (ldapDisplayName 'company')
         [ValidateNotNull()]
         [System.String] $Company,
 
-        ## Specifies the location of the user's office or place of business (ldapDisplayName 'physicalDeliveryOfficeName')
+        # Specifies the location of the user's office or place of business (ldapDisplayName 'physicalDeliveryOfficeName')
         [ValidateNotNull()]
         [System.String] $Office,
 
-        ## Specifies the user's title (ldapDisplayName 'title')
+        # Specifies the user's title (ldapDisplayName 'title')
         [ValidateNotNull()]
         [System.String] $JobTitle,
 
-        ## Specifies the user's e-mail address (ldapDisplayName 'mail')
+        # Specifies the user's e-mail address (ldapDisplayName 'mail')
         [ValidateNotNull()]
         [System.String] $EmailAddress,
 
-        ## Specifies the user's employee ID (ldapDisplayName 'employeeID')
+        # Specifies the user's employee ID (ldapDisplayName 'employeeID')
         [ValidateNotNull()]
         [System.String] $EmployeeID,
 
-        ## Specifies the user's employee number (ldapDisplayName 'employeeNumber')
+        # Specifies the user's employee number (ldapDisplayName 'employeeNumber')
         [ValidateNotNull()]
         [System.String] $EmployeeNumber,
 
-        ## Specifies a user's home directory path (ldapDisplayName 'homeDirectory')
+        # Specifies a user's home directory path (ldapDisplayName 'homeDirectory')
         [ValidateNotNull()]
         [System.String] $HomeDirectory,
 
-        ## Specifies a drive that is associated with the UNC path defined by the HomeDirectory property (ldapDisplayName 'homeDrive')
+        # Specifies a drive that is associated with the UNC path defined by the HomeDirectory property (ldapDisplayName 'homeDrive')
         [ValidateNotNull()]
         [System.String] $HomeDrive,
 
-        ## Specifies the URL of the home page of the object (ldapDisplayName 'wWWHomePage')
+        # Specifies the URL of the home page of the object (ldapDisplayName 'wWWHomePage')
         [ValidateNotNull()]
         [System.String] $HomePage,
 
-        ## Specifies a path to the user's profile (ldapDisplayName 'profilePath')
+        # Specifies a path to the user's profile (ldapDisplayName 'profilePath')
         [ValidateNotNull()]
         [System.String] $ProfilePath,
 
-        ## Specifies a path to the user's log on script (ldapDisplayName 'scriptPath')
+        # Specifies a path to the user's log on script (ldapDisplayName 'scriptPath')
         [ValidateNotNull()]
         [System.String] $LogonScript,
 
-        ## Specifies the notes attached to the user's accoutn (ldapDisplayName 'info')
+        # Specifies the notes attached to the user's accoutn (ldapDisplayName 'info')
         [ValidateNotNull()]
         [System.String] $Notes,
 
-        ## Specifies the user's office telephone number (ldapDisplayName 'telephoneNumber')
+        # Specifies the user's office telephone number (ldapDisplayName 'telephoneNumber')
         [ValidateNotNull()]
         [System.String] $OfficePhone,
 
-        ## Specifies the user's mobile phone number (ldapDisplayName 'mobile')
+        # Specifies the user's mobile phone number (ldapDisplayName 'mobile')
         [ValidateNotNull()]
         [System.String] $MobilePhone,
 
-        ## Specifies the user's fax phone number (ldapDisplayName 'facsimileTelephoneNumber')
+        # Specifies the user's fax phone number (ldapDisplayName 'facsimileTelephoneNumber')
         [ValidateNotNull()]
         [System.String] $Fax,
 
-        ## Specifies the user's home telephone number (ldapDisplayName 'homePhone')
+        # Specifies the user's home telephone number (ldapDisplayName 'homePhone')
         [ValidateNotNull()]
         [System.String] $HomePhone,
 
-         ## Specifies the user's pager number (ldapDisplayName 'pager')
+         # Specifies the user's pager number (ldapDisplayName 'pager')
         [ValidateNotNull()]
         [System.String] $Pager,
 
-        ## Specifies the user's IP telephony phone number (ldapDisplayName 'ipPhone')
+        # Specifies the user's IP telephony phone number (ldapDisplayName 'ipPhone')
         [ValidateNotNull()]
         [System.String] $IPPhone,
 
-        ## Specifies the user's manager specified as a Distinguished Name (ldapDisplayName 'manager')
+        # Specifies the user's manager specified as a Distinguished Name (ldapDisplayName 'manager')
         [ValidateNotNull()]
         [System.String] $Manager,
 
-        ## Specifies if the account is enabled (default True)
+        # Specifies if the account is enabled (default True)
         [ValidateNotNull()]
         [System.Boolean] $Enabled = $true,
 
-        ## Specifies whether the account password can be changed
+        # Specifies whether the account password can be changed
         [ValidateNotNull()]
         [System.Boolean] $CannotChangePassword,
 
-        ## Specifies whether the password of an account can expire
+        # Specifies whether the password of an account can expire
         [ValidateNotNull()]
         [System.Boolean] $PasswordNeverExpires,
 
-        ## Specifies the Active Directory Domain Services instance to use to perform the task.
+        # Specifies the Active Directory Domain Services instance to use to perform the task.
         [ValidateNotNull()]
         [System.String] $DomainController,
 
-        ## Specifies the user account credentials to use to perform this task. Ideally this should just be called 'Credential' but is here for backwards compatibility
+        # Specifies the user account credentials to use to perform this task. Ideally this should just be called 'Credential' but is here for backwards compatibility
         [ValidateNotNull()]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.CredentialAttribute()]
         $DomainAdministratorCredential,
 
-        ## Specifies the authentication context type when testing user passwords #61
+        # Specifies the authentication context type when testing user passwords #61
         [ValidateSet('Default','Negotiate')]
         [System.String] $PasswordAuthentication = 'Default',
 
-        ## Indicates whether or not the user object should first tried to be restored from the recycle bin before creating a new computer object.
+        # Indicates whether or not the user object should first tried to be restored from the recycle bin before creating a new user object.
         [ValidateNotNull()]
-        [System.Boolean] $RestoreFromRecycleBin
+        [System.Boolean]
+        $RestoreFromRecycleBin
     )
 
     Assert-Module -ModuleName 'ActiveDirectory';
@@ -280,7 +281,7 @@ function Get-TargetResource
         $adCommonParameters = Get-ADCommonParameters @PSBoundParameters;
 
         $adProperties = @();
-        ## Create an array of the AD propertie names to retrieve from the property map
+        # Create an array of the AD propertie names to retrieve from the property map
         foreach ($property in $adPropertyMap)
         {
             if ($property.ADProperty)
@@ -313,16 +314,16 @@ function Get-TargetResource
         DomainName        = $DomainName;
         Password          = $Password;
         UserName          = $UserName;
-        DistinguishedName = $adUser.DistinguishedName; ## Read-only property
+        DistinguishedName = $adUser.DistinguishedName; # Read-only property
         Ensure            = $Ensure;
         DomainController  = $DomainController;
     }
 
-    ## Retrieve each property from the ADPropertyMap and add to the hashtable
+    # Retrieve each property from the ADPropertyMap and add to the hashtable
     foreach ($property in $adPropertyMap)
     {
         if ($property.Parameter -eq 'Path') {
-            ## The path returned is not the parent container
+            # The path returned is not the parent container
             if (-not [System.String]::IsNullOrEmpty($adUser.DistinguishedName))
             {
                 $targetResource['Path'] = Get-ADObjectParentDN -DN $adUser.DistinguishedName;
@@ -330,12 +331,12 @@ function Get-TargetResource
         }
         elseif ($property.ADProperty)
         {
-            ## The AD property name is different to the function parameter to use this
+            # The AD property name is different to the function parameter to use this
             $targetResource[$property.Parameter] = $adUser.($property.ADProperty);
         }
         else
         {
-            ## The AD property name matches the function parameter
+            # The AD property name matches the function parameter
             $targetResource[$property.Parameter] = $adUser.($property.Parameter);
         }
     }
@@ -349,7 +350,7 @@ function Test-TargetResource
     [OutputType([System.Boolean])]
     param
     (
-        ## Name of the domain where the user account is located (only used if password is managed)
+        # Name of the domain where the user account is located (only used if password is managed)
         [Parameter(Mandatory)]
         [System.String] $DomainName,
 
@@ -357,185 +358,186 @@ function Test-TargetResource
         [Parameter(Mandatory)]
         [System.String] $UserName,
 
-        ## Specifies a new password value for an account
+        # Specifies a new password value for an account
         [ValidateNotNull()]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.CredentialAttribute()]
         $Password,
 
-        ## Specifies whether the user account is created or deleted
+        # Specifies whether the user account is created or deleted
         [ValidateSet('Present', 'Absent')]
         [System.String] $Ensure = 'Present',
 
-        ## Specifies the common nane assigned to the user account (ldapDisplayName 'cn')
+        # Specifies the common nane assigned to the user account (ldapDisplayName 'cn')
         [ValidateNotNull()]
         [System.String] $CommonName = $UserName,
 
-        ## Specifies the UPN assigned to the user account (ldapDisplayName 'userPrincipalName')
+        # Specifies the UPN assigned to the user account (ldapDisplayName 'userPrincipalName')
         [ValidateNotNull()]
         [System.String] $UserPrincipalName,
 
-        ## Specifies the display name of the object (ldapDisplayName 'displayName')
+        # Specifies the display name of the object (ldapDisplayName 'displayName')
         [ValidateNotNull()]
         [System.String] $DisplayName,
 
-        ## Specifies the X.500 path of the Organizational Unit (OU) or container where the new object is created
+        # Specifies the X.500 path of the Organizational Unit (OU) or container where the new object is created
         [ValidateNotNull()]
         [System.String] $Path,
 
-        ## Specifies the user's given name (ldapDisplayName 'givenName')
+        # Specifies the user's given name (ldapDisplayName 'givenName')
         [ValidateNotNull()]
         [System.String] $GivenName,
 
-        ## Specifies the initials that represent part of a user's name (ldapDisplayName 'initials')
+        # Specifies the initials that represent part of a user's name (ldapDisplayName 'initials')
         [ValidateNotNull()]
         [System.String] $Initials,
 
-        ## Specifies the user's last name or surname (ldapDisplayName 'sn')
+        # Specifies the user's last name or surname (ldapDisplayName 'sn')
         [ValidateNotNull()]
         [System.String] $Surname,
 
-        ## Specifies a description of the object (ldapDisplayName 'description')
+        # Specifies a description of the object (ldapDisplayName 'description')
         [ValidateNotNull()]
         [System.String] $Description,
 
-        ## Specifies the user's street address (ldapDisplayName 'streetAddress')
+        # Specifies the user's street address (ldapDisplayName 'streetAddress')
         [ValidateNotNull()]
         [System.String] $StreetAddress,
 
-        ## Specifies the user's post office box number (ldapDisplayName 'postOfficeBox')
+        # Specifies the user's post office box number (ldapDisplayName 'postOfficeBox')
         [ValidateNotNull()]
         [System.String] $POBox,
 
-        ## Specifies the user's town or city (ldapDisplayName 'l')
+        # Specifies the user's town or city (ldapDisplayName 'l')
         [ValidateNotNull()]
         [System.String] $City,
 
-        ## Specifies the user's or Organizational Unit's state or province (ldapDisplayName 'st')
+        # Specifies the user's or Organizational Unit's state or province (ldapDisplayName 'st')
         [ValidateNotNull()]
         [System.String] $State,
 
-        ## Specifies the user's postal code or zip code (ldapDisplayName 'postalCode')
+        # Specifies the user's postal code or zip code (ldapDisplayName 'postalCode')
         [ValidateNotNull()]
         [System.String] $PostalCode,
 
-        ## Specifies the country or region code for the user's language of choice (ldapDisplayName 'c')
+        # Specifies the country or region code for the user's language of choice (ldapDisplayName 'c')
         [ValidateNotNull()]
         [System.String] $Country,
 
-        ## Specifies the user's department (ldapDisplayName 'department')
+        # Specifies the user's department (ldapDisplayName 'department')
         [ValidateNotNull()]
         [System.String] $Department,
 
-        ## Specifies the user's division (ldapDisplayName 'division')
+        # Specifies the user's division (ldapDisplayName 'division')
         [ValidateNotNull()]
         [System.String] $Division,
 
-        ## Specifies the user's company (ldapDisplayName 'company')
+        # Specifies the user's company (ldapDisplayName 'company')
         [ValidateNotNull()]
         [System.String] $Company,
 
-        ## Specifies the location of the user's office or place of business (ldapDisplayName 'physicalDeliveryOfficeName')
+        # Specifies the location of the user's office or place of business (ldapDisplayName 'physicalDeliveryOfficeName')
         [ValidateNotNull()]
         [System.String] $Office,
 
-        ## Specifies the user's title (ldapDisplayName 'title')
+        # Specifies the user's title (ldapDisplayName 'title')
         [ValidateNotNull()]
         [System.String] $JobTitle,
 
-        ## Specifies the user's e-mail address (ldapDisplayName 'mail')
+        # Specifies the user's e-mail address (ldapDisplayName 'mail')
         [ValidateNotNull()]
         [System.String] $EmailAddress,
 
-        ## Specifies the user's employee ID (ldapDisplayName 'employeeID')
+        # Specifies the user's employee ID (ldapDisplayName 'employeeID')
         [ValidateNotNull()]
         [System.String] $EmployeeID,
 
-        ## Specifies the user's employee number (ldapDisplayName 'employeeNumber')
+        # Specifies the user's employee number (ldapDisplayName 'employeeNumber')
         [ValidateNotNull()]
         [System.String] $EmployeeNumber,
 
-        ## Specifies a user's home directory path (ldapDisplayName 'homeDirectory')
+        # Specifies a user's home directory path (ldapDisplayName 'homeDirectory')
         [ValidateNotNull()]
         [System.String] $HomeDirectory,
 
-        ## Specifies a drive that is associated with the UNC path defined by the HomeDirectory property (ldapDisplayName 'homeDrive')
+        # Specifies a drive that is associated with the UNC path defined by the HomeDirectory property (ldapDisplayName 'homeDrive')
         [ValidateNotNull()]
         [System.String] $HomeDrive,
 
-        ## Specifies the URL of the home page of the object (ldapDisplayName 'wWWHomePage')
+        # Specifies the URL of the home page of the object (ldapDisplayName 'wWWHomePage')
         [ValidateNotNull()]
         [System.String] $HomePage,
 
-        ## Specifies a path to the user's profile (ldapDisplayName 'profilePath')
+        # Specifies a path to the user's profile (ldapDisplayName 'profilePath')
         [ValidateNotNull()]
         [System.String] $ProfilePath,
 
-        ## Specifies a path to the user's log on script (ldapDisplayName 'scriptPath')
+        # Specifies a path to the user's log on script (ldapDisplayName 'scriptPath')
         [ValidateNotNull()]
         [System.String] $LogonScript,
 
-        ## Specifies the notes attached to the user's accoutn (ldapDisplayName 'info')
+        # Specifies the notes attached to the user's accoutn (ldapDisplayName 'info')
         [ValidateNotNull()]
         [System.String] $Notes,
 
-        ## Specifies the user's office telephone number (ldapDisplayName 'telephoneNumber')
+        # Specifies the user's office telephone number (ldapDisplayName 'telephoneNumber')
         [ValidateNotNull()]
         [System.String] $OfficePhone,
 
-        ## Specifies the user's mobile phone number (ldapDisplayName 'mobile')
+        # Specifies the user's mobile phone number (ldapDisplayName 'mobile')
         [ValidateNotNull()]
         [System.String] $MobilePhone,
 
-        ## Specifies the user's fax phone number (ldapDisplayName 'facsimileTelephoneNumber')
+        # Specifies the user's fax phone number (ldapDisplayName 'facsimileTelephoneNumber')
         [ValidateNotNull()]
         [System.String] $Fax,
 
-        ## Specifies the user's home telephone number (ldapDisplayName 'homePhone')
+        # Specifies the user's home telephone number (ldapDisplayName 'homePhone')
         [ValidateNotNull()]
         [System.String] $HomePhone,
 
-         ## Specifies the user's pager number (ldapDisplayName 'pager')
+         # Specifies the user's pager number (ldapDisplayName 'pager')
         [ValidateNotNull()]
         [System.String] $Pager,
 
-        ## Specifies the user's IP telephony phone number (ldapDisplayName 'ipPhone')
+        # Specifies the user's IP telephony phone number (ldapDisplayName 'ipPhone')
         [ValidateNotNull()]
         [System.String] $IPPhone,
 
-        ## Specifies the user's manager specified as a Distinguished Name (ldapDisplayName 'manager')
+        # Specifies the user's manager specified as a Distinguished Name (ldapDisplayName 'manager')
         [ValidateNotNull()]
         [System.String] $Manager,
 
-        ## Specifies if the account is enabled (default True)
+        # Specifies if the account is enabled (default True)
         [ValidateNotNull()]
         [System.Boolean] $Enabled = $true,
 
-        ## Specifies whether the account password can be changed
+        # Specifies whether the account password can be changed
         [ValidateNotNull()]
         [System.Boolean] $CannotChangePassword,
 
-        ## Specifies whether the password of an account can expire
+        # Specifies whether the password of an account can expire
         [ValidateNotNull()]
         [System.Boolean] $PasswordNeverExpires,
 
-        ## Specifies the Active Directory Domain Services instance to use to perform the task.
+        # Specifies the Active Directory Domain Services instance to use to perform the task.
         [ValidateNotNull()]
         [System.String] $DomainController,
 
-        ## Specifies the user account credentials to use to perform this task. Ideally this should just be called 'Credential' but is here for backwards compatibility
+        # Specifies the user account credentials to use to perform this task. Ideally this should just be called 'Credential' but is here for backwards compatibility
         [ValidateNotNull()]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.CredentialAttribute()]
         $DomainAdministratorCredential,
 
-        ## Specifies the authentication context type when testing user passwords #61
+        # Specifies the authentication context type when testing user passwords #61
         [ValidateSet('Default','Negotiate')]
         [System.String] $PasswordAuthentication = 'Default',
 
-        ## Indicates whether or not the computer object should first tried to be restored from the recycle bin before creating a new computer object.
+        # Indicates whether or not the user object should first tried to be restored from the recycle bin before creating a new user object.
         [ValidateNotNull()]
-        [System.Boolean] $RestoreFromRecycleBin
+        [System.Boolean]
+        $RestoreFromRecycleBin
     )
 
     Assert-Parameters @PSBoundParameters;
@@ -552,7 +554,7 @@ function Test-TargetResource
     }
     else
     {
-        ## Add common name, ensure and enabled as they may not be explicitly passed and we want to enumerate them
+        # Add common name, ensure and enabled as they may not be explicitly passed and we want to enumerate them
         $PSBoundParameters['Ensure'] = $Ensure;
         $PSBoundParameters['Enabled'] = $Enabled;
 
@@ -579,7 +581,7 @@ function Test-TargetResource
             # Only check properties that are returned by Get-TargetResource
             elseif ($targetResource.ContainsKey($parameter))
             {
-                ## This check is required to be able to explicitly remove values with an empty string, if required
+                # This check is required to be able to explicitly remove values with an empty string, if required
                 if (([System.String]::IsNullOrEmpty($PSBoundParameters.$parameter)) -and ([System.String]::IsNullOrEmpty($targetResource.$parameter)))
                 {
                     # Both values are null/empty and therefore we are compliant
@@ -602,7 +604,7 @@ function Set-TargetResource
     [CmdletBinding()]
     param
     (
-        ## Name of the domain where the user account is located (only used if password is managed)
+        # Name of the domain where the user account is located (only used if password is managed)
         [Parameter(Mandatory)]
         [System.String] $DomainName,
 
@@ -610,191 +612,192 @@ function Set-TargetResource
         [Parameter(Mandatory)]
         [System.String] $UserName,
 
-        ## Specifies a new password value for an account
+        # Specifies a new password value for an account
         [ValidateNotNull()]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.CredentialAttribute()]
         $Password,
 
-        ## Specifies whether the user account is created or deleted
+        # Specifies whether the user account is created or deleted
         [ValidateSet('Present', 'Absent')]
         [System.String] $Ensure = 'Present',
 
-        ## Specifies the common nane assigned to the user account (ldapDisplayName 'cn')
+        # Specifies the common nane assigned to the user account (ldapDisplayName 'cn')
         [ValidateNotNull()]
         [System.String] $CommonName = $UserName,
 
-        ## Specifies the UPN assigned to the user account (ldapDisplayName 'userPrincipalName')
+        # Specifies the UPN assigned to the user account (ldapDisplayName 'userPrincipalName')
         [ValidateNotNull()]
         [System.String] $UserPrincipalName,
 
-        ## Specifies the display name of the object (ldapDisplayName 'displayName')
+        # Specifies the display name of the object (ldapDisplayName 'displayName')
         [ValidateNotNull()]
         [System.String] $DisplayName,
 
-        ## Specifies the X.500 path of the Organizational Unit (OU) or container where the new object is created
+        # Specifies the X.500 path of the Organizational Unit (OU) or container where the new object is created
         [ValidateNotNull()]
         [System.String] $Path,
 
-        ## Specifies the user's given name (ldapDisplayName 'givenName')
+        # Specifies the user's given name (ldapDisplayName 'givenName')
         [ValidateNotNull()]
         [System.String] $GivenName,
 
-        ## Specifies the initials that represent part of a user's name (ldapDisplayName 'initials')
+        # Specifies the initials that represent part of a user's name (ldapDisplayName 'initials')
         [ValidateNotNull()]
         [System.String] $Initials,
 
-        ## Specifies the user's last name or surname (ldapDisplayName 'sn')
+        # Specifies the user's last name or surname (ldapDisplayName 'sn')
         [ValidateNotNull()]
         [System.String] $Surname,
 
-        ## Specifies a description of the object (ldapDisplayName 'description')
+        # Specifies a description of the object (ldapDisplayName 'description')
         [ValidateNotNull()]
         [System.String] $Description,
 
-        ## Specifies the user's street address (ldapDisplayName 'streetAddress')
+        # Specifies the user's street address (ldapDisplayName 'streetAddress')
         [ValidateNotNull()]
         [System.String] $StreetAddress,
 
-        ## Specifies the user's post office box number (ldapDisplayName 'postOfficeBox')
+        # Specifies the user's post office box number (ldapDisplayName 'postOfficeBox')
         [ValidateNotNull()]
         [System.String] $POBox,
 
-        ## Specifies the user's town or city (ldapDisplayName 'l')
+        # Specifies the user's town or city (ldapDisplayName 'l')
         [ValidateNotNull()]
         [System.String] $City,
 
-        ## Specifies the user's or Organizational Unit's state or province (ldapDisplayName 'st')
+        # Specifies the user's or Organizational Unit's state or province (ldapDisplayName 'st')
         [ValidateNotNull()]
         [System.String] $State,
 
-        ## Specifies the user's postal code or zip code (ldapDisplayName 'postalCode')
+        # Specifies the user's postal code or zip code (ldapDisplayName 'postalCode')
         [ValidateNotNull()]
         [System.String] $PostalCode,
 
-        ## Specifies the country or region code for the user's language of choice (ldapDisplayName 'c')
+        # Specifies the country or region code for the user's language of choice (ldapDisplayName 'c')
         [ValidateNotNull()]
         [System.String] $Country,
 
-        ## Specifies the user's department (ldapDisplayName 'department')
+        # Specifies the user's department (ldapDisplayName 'department')
         [ValidateNotNull()]
         [System.String] $Department,
 
-        ## Specifies the user's division (ldapDisplayName 'division')
+        # Specifies the user's division (ldapDisplayName 'division')
         [ValidateNotNull()]
         [System.String] $Division,
 
-        ## Specifies the user's company (ldapDisplayName 'company')
+        # Specifies the user's company (ldapDisplayName 'company')
         [ValidateNotNull()]
         [System.String] $Company,
 
-        ## Specifies the location of the user's office or place of business (ldapDisplayName 'physicalDeliveryOfficeName')
+        # Specifies the location of the user's office or place of business (ldapDisplayName 'physicalDeliveryOfficeName')
         [ValidateNotNull()]
         [System.String] $Office,
 
-        ## Specifies the user's title (ldapDisplayName 'title')
+        # Specifies the user's title (ldapDisplayName 'title')
         [ValidateNotNull()]
         [System.String] $JobTitle,
 
-        ## Specifies the user's e-mail address (ldapDisplayName 'mail')
+        # Specifies the user's e-mail address (ldapDisplayName 'mail')
         [ValidateNotNull()]
         [System.String] $EmailAddress,
 
-        ## Specifies the user's employee ID (ldapDisplayName 'employeeID')
+        # Specifies the user's employee ID (ldapDisplayName 'employeeID')
         [ValidateNotNull()]
         [System.String] $EmployeeID,
 
-        ## Specifies the user's employee number (ldapDisplayName 'employeeNumber')
+        # Specifies the user's employee number (ldapDisplayName 'employeeNumber')
         [ValidateNotNull()]
         [System.String] $EmployeeNumber,
 
-        ## Specifies a user's home directory path (ldapDisplayName 'homeDirectory')
+        # Specifies a user's home directory path (ldapDisplayName 'homeDirectory')
         [ValidateNotNull()]
         [System.String] $HomeDirectory,
 
-        ## Specifies a drive that is associated with the UNC path defined by the HomeDirectory property (ldapDisplayName 'homeDrive')
+        # Specifies a drive that is associated with the UNC path defined by the HomeDirectory property (ldapDisplayName 'homeDrive')
         [ValidateNotNull()]
         [System.String] $HomeDrive,
 
-        ## Specifies the URL of the home page of the object (ldapDisplayName 'wWWHomePage')
+        # Specifies the URL of the home page of the object (ldapDisplayName 'wWWHomePage')
         [ValidateNotNull()]
         [System.String] $HomePage,
 
-        ## Specifies a path to the user's profile (ldapDisplayName 'profilePath')
+        # Specifies a path to the user's profile (ldapDisplayName 'profilePath')
         [ValidateNotNull()]
         [System.String] $ProfilePath,
 
-        ## Specifies a path to the user's log on script (ldapDisplayName 'scriptPath')
+        # Specifies a path to the user's log on script (ldapDisplayName 'scriptPath')
         [ValidateNotNull()]
         [System.String] $LogonScript,
 
-        ## Specifies the notes attached to the user's accoutn (ldapDisplayName 'info')
+        # Specifies the notes attached to the user's accoutn (ldapDisplayName 'info')
         [ValidateNotNull()]
         [System.String] $Notes,
 
-        ## Specifies the user's office telephone number (ldapDisplayName 'telephoneNumber')
+        # Specifies the user's office telephone number (ldapDisplayName 'telephoneNumber')
         [ValidateNotNull()]
         [System.String] $OfficePhone,
 
-        ## Specifies the user's mobile phone number (ldapDisplayName 'mobile')
+        # Specifies the user's mobile phone number (ldapDisplayName 'mobile')
         [ValidateNotNull()]
         [System.String] $MobilePhone,
 
-        ## Specifies the user's fax phone number (ldapDisplayName 'facsimileTelephoneNumber')
+        # Specifies the user's fax phone number (ldapDisplayName 'facsimileTelephoneNumber')
         [ValidateNotNull()]
         [System.String] $Fax,
 
-        ## Specifies the user's home telephone number (ldapDisplayName 'homePhone')
+        # Specifies the user's home telephone number (ldapDisplayName 'homePhone')
         [ValidateNotNull()]
         [System.String] $HomePhone,
 
-         ## Specifies the user's pager number (ldapDisplayName 'pager')
+         # Specifies the user's pager number (ldapDisplayName 'pager')
         [ValidateNotNull()]
         [System.String] $Pager,
 
-        ## Specifies the user's IP telephony phone number (ldapDisplayName 'ipPhone')
+        # Specifies the user's IP telephony phone number (ldapDisplayName 'ipPhone')
         [ValidateNotNull()]
         [System.String] $IPPhone,
 
-        ## Specifies the user's manager specified as a Distinguished Name (ldapDisplayName 'manager')
+        # Specifies the user's manager specified as a Distinguished Name (ldapDisplayName 'manager')
         [ValidateNotNull()]
         [System.String] $Manager,
 
-        ## Specifies if the account is enabled (default True)
+        # Specifies if the account is enabled (default True)
         [ValidateNotNull()]
         [System.Boolean] $Enabled = $true,
 
-        ## Specifies whether the account password can be changed
+        # Specifies whether the account password can be changed
         [ValidateNotNull()]
         [System.Boolean] $CannotChangePassword,
 
-        ## Specifies whether the password of an account can expire
+        # Specifies whether the password of an account can expire
         [ValidateNotNull()]
         [System.Boolean] $PasswordNeverExpires,
 
-        ## Specifies the Active Directory Domain Services instance to use to perform the task.
+        # Specifies the Active Directory Domain Services instance to use to perform the task.
         [ValidateNotNull()]
         [System.String] $DomainController,
 
-        ## Specifies the user account credentials to use to perform this task. Ideally this should just be called 'Credential' but is here for backwards compatibility
+        # Specifies the user account credentials to use to perform this task. Ideally this should just be called 'Credential' but is here for backwards compatibility
         [ValidateNotNull()]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.CredentialAttribute()]
         $DomainAdministratorCredential,
 
-        ## Specifies the authentication context type when testing user passwords #61
+        # Specifies the authentication context type when testing user passwords #61
         [ValidateSet('Default','Negotiate')]
         [System.String] $PasswordAuthentication = 'Default',
 
-        ## Indicates whether or not the computer object should first tried to be restored from the recycle bin before creating a new computer object.
+        # Indicates whether or not the user object should first tried to be restored from the recycle bin before creating a new user object.
         [ValidateNotNull()]
-        [System.Boolean] $RestoreFromRecycleBin
+        [System.Boolean]
+        $RestoreFromRecycleBin
     )
 
     Assert-Parameters @PSBoundParameters;
     $targetResource = Get-TargetResource @PSBoundParameters;
 
-    ## Add common name, ensure and enabled as they may not be explicitly passed
+    # Add common name, ensure and enabled as they may not be explicitly passed
     $PSBoundParameters['Ensure'] = $Ensure;
     $PSBoundParameters['Enabled'] = $Enabled;
 
@@ -802,17 +805,17 @@ function Set-TargetResource
     {
         if ($targetResource.Ensure -eq 'Absent') {
 
-            ## Try to restore account if it exists
+            # Try to restore account if it exists
             if($RestoreFromRecycleBin)
             {
                 Write-Verbose -Message ($LocalizedData.RestoringUser -f $UserName)
                 $restoreParams = Get-ADCommonParameters @PSBoundParameters
-                $restorationSuccessful = Restore-ADCommonObject @restoreParams -ObjectClass User -ErrorAction Stop -PassThru
+                $restorationSuccessful = Restore-ADCommonObject @restoreParams -ObjectClass User -ErrorAction Stop
             }
 
             if (-not $RestoreFromRecycleBin -or ($RestoreFromRecycleBin -and -not $restorationSuccessful))
             {
-                ## User does not exist and needs creating
+                # User does not exist and needs creating
                 $newADUserParams = Get-ADCommonParameters @PSBoundParameters -UseNameParameter;
                 if ($PSBoundParameters.ContainsKey('Path'))
                 {
@@ -820,7 +823,7 @@ function Set-TargetResource
                 }
                 Write-Verbose -Message ($LocalizedData.AddingADUser -f $UserName);
                 New-ADUser @newADUserParams -SamAccountName $UserName;
-                ## Now retrieve the newly created user
+                # Now retrieve the newly created user
                 $targetResource = Get-TargetResource @PSBoundParameters;
             }
         }
@@ -830,24 +833,24 @@ function Set-TargetResource
         $removeUserProperties = @{};
         foreach ($parameter in $PSBoundParameters.Keys)
         {
-            ## Only check/action properties specified/declared parameters that match one of the function's
-            ## parameters. This will ignore common parameters such as -Verbose etc.
+            # Only check/action properties specified/declared parameters that match one of the function's
+            # parameters. This will ignore common parameters such as -Verbose etc.
             if ($targetResource.ContainsKey($parameter))
             {
                 if ($parameter -eq 'Path' -and ($PSBoundParameters.Path -ne $targetResource.Path))
                 {
-                    ## Cannot move users by updating the DistinguishedName property
+                    # Cannot move users by updating the DistinguishedName property
                     $adCommonParameters = Get-ADCommonParameters @PSBoundParameters;
-                    ## Using the SamAccountName for identity with Move-ADObject does not work, use the DN instead
+                    # Using the SamAccountName for identity with Move-ADObject does not work, use the DN instead
                     $adCommonParameters['Identity'] = $targetResource.DistinguishedName;
                     Write-Verbose -Message ($LocalizedData.MovingADUser -f $targetResource.Path, $PSBoundParameters.Path);
                     Move-ADObject @adCommonParameters -TargetPath $PSBoundParameters.Path;
                 }
                 elseif ($parameter -eq 'CommonName' -and ($PSBoundParameters.CommonName -ne $targetResource.CommonName))
                 {
-                    ## Cannot rename users by updating the CN property directly
+                    # Cannot rename users by updating the CN property directly
                     $adCommonParameters = Get-ADCommonParameters @PSBoundParameters;
-                    ## Using the SamAccountName for identity with Rename-ADObject does not work, use the DN instead
+                    # Using the SamAccountName for identity with Rename-ADObject does not work, use the DN instead
                     $adCommonParameters['Identity'] = $targetResource.DistinguishedName;
                     Write-Verbose -Message ($LocalizedData.RenamingADUser -f $targetResource.CommonName, $PSBoundParameters.CommonName);
                     Rename-ADObject @adCommonParameters -NewName $PSBoundParameters.CommonName;
@@ -860,29 +863,29 @@ function Set-TargetResource
                 }
                 elseif ($parameter -eq 'Enabled' -and ($PSBoundParameters.$parameter -ne $targetResource.$parameter))
                 {
-                    ## We cannot enable/disable an account with -Add or -Replace parameters, but inform that
-                    ## we will change this as it is out of compliance (it always gets set anyway)
+                    # We cannot enable/disable an account with -Add or -Replace parameters, but inform that
+                    # we will change this as it is out of compliance (it always gets set anyway)
                     Write-Verbose -Message ($LocalizedData.UpdatingADUserProperty -f $parameter, $PSBoundParameters.$parameter);
                 }
                 elseif ($PSBoundParameters.$parameter -ne $targetResource.$parameter)
                 {
-                    ## Find the associated AD property
+                    # Find the associated AD property
                     $adProperty = $adPropertyMap | Where-Object { $_.Parameter -eq $parameter };
 
                     if ([System.String]::IsNullOrEmpty($adProperty))
                     {
-                        ## We can't do anything is an empty AD property!
+                        # We can't do anything is an empty AD property!
                     }
                     elseif ([System.String]::IsNullOrEmpty($PSBoundParameters.$parameter))
                     {
-                        ## We are removing properties
-                        ## Only remove if the existing value in not null or empty
+                        # We are removing properties
+                        # Only remove if the existing value in not null or empty
                         if (-not ([System.String]::IsNullOrEmpty($targetResource.$parameter)))
                         {
                             Write-Verbose -Message ($LocalizedData.RemovingADUserProperty -f $parameter, $PSBoundParameters.$parameter);
                             if ($adProperty.UseCmdletParameter -eq $true)
                             {
-                                ## We need to pass the parameter explicitly to Set-ADUser, not via -Remove
+                                # We need to pass the parameter explicitly to Set-ADUser, not via -Remove
                                 $setADUserParams[$adProperty.Parameter] = $PSBoundParameters.$parameter;
                             }
                             elseif ([System.String]::IsNullOrEmpty($adProperty.ADProperty))
@@ -897,11 +900,11 @@ function Set-TargetResource
                     } #end if remove existing value
                     else
                     {
-                        ## We are replacing the existing value
+                        # We are replacing the existing value
                         Write-Verbose -Message ($LocalizedData.UpdatingADUserProperty -f $parameter, $PSBoundParameters.$parameter);
                         if ($adProperty.UseCmdletParameter -eq $true)
                         {
-                            ## We need to pass the parameter explicitly to Set-ADUser, not via -Replace
+                            # We need to pass the parameter explicitly to Set-ADUser, not via -Replace
                             $setADUserParams[$adProperty.Parameter] = $PSBoundParameters.$parameter;
                         }
                         elseif ([System.String]::IsNullOrEmpty($adProperty.ADProperty))
@@ -918,7 +921,7 @@ function Set-TargetResource
             } #end if TargetResource parameter
         } #end foreach PSBoundParameter
 
-        ## Only pass -Remove and/or -Replace if we have something to set/change
+        # Only pass -Remove and/or -Replace if we have something to set/change
         if ($replaceUserProperties.Count -gt 0)
         {
             $setADUserParams['Replace'] = $replaceUserProperties;
@@ -933,7 +936,7 @@ function Set-TargetResource
     }
     elseif (($Ensure -eq 'Absent') -and ($targetResource.Ensure -eq 'Present'))
     {
-        ## User exists and needs removing
+        # User exists and needs removing
         Write-Verbose ($LocalizedData.RemovingADUser -f $UserName);
         $adCommonParameters = Get-ADCommonParameters @PSBoundParameters;
         [ref] $null = Remove-ADUser @adCommonParameters -Confirm:$false;
@@ -957,7 +960,7 @@ function Assert-Parameters
         $IgnoredArguments
     )
 
-    ## We cannot test/set passwords on disabled AD accounts
+    # We cannot test/set passwords on disabled AD accounts
     if (($PSBoundParameters.ContainsKey('Password')) -and ($Enabled -eq $false))
     {
         $throwInvalidArgumentErrorParams = @{
@@ -991,7 +994,7 @@ function Test-Password
         [System.Management.Automation.CredentialAttribute()]
         $DomainAdministratorCredential,
 
-        ## Specifies the authentication context type when testing user passwords #61
+        # Specifies the authentication context type when testing user passwords #61
         [Parameter(Mandatory)]
         [ValidateSet('Default','Negotiate')]
         [System.String] $PasswordAuthentication
@@ -1032,7 +1035,7 @@ function Test-Password
     }
     else
     {
-        ## Use default authentication context
+        # Use default authentication context
         return $principalContext.ValidateCredentials(
             $UserName,
             $Password.GetNetworkCredential().Password

--- a/DSCResources/MSFT_xADUser/MSFT_xADUser.schema.mof
+++ b/DSCResources/MSFT_xADUser/MSFT_xADUser.schema.mof
@@ -46,6 +46,6 @@ class MSFT_xADUser : OMI_BaseResource
     [Write, Description("Specifies the Active Directory Domain Services instance to use to perform the task.")] String DomainController;
     [Write, Description("Specifies the user account credentials to use to perform this task"), EmbeddedInstance("MSFT_Credential")] String DomainAdministratorCredential;
     [Write, Description("Specifies the authentication context type used when testing passwords"), ValueMap{"Default","Negotiate"},Values{"Default","Negotiate"}] String PasswordAuthentication;
-    [Write, Description("Indicates whether or not objects should be restored from recycle bin instead of recreating them")] Boolean RestoreFromRecycleBin;
+    [Write, Description("Indicates whether or not the user object should first tried to be restored from the recycle bin before creating a new computer object.")] Boolean RestoreFromRecycleBin;
     [Read, Description("Returns the X.500 path of the object")] String DistinguishedName;
 };

--- a/DSCResources/MSFT_xADUser/MSFT_xADUser.schema.mof
+++ b/DSCResources/MSFT_xADUser/MSFT_xADUser.schema.mof
@@ -46,6 +46,6 @@ class MSFT_xADUser : OMI_BaseResource
     [Write, Description("Specifies the Active Directory Domain Services instance to use to perform the task.")] String DomainController;
     [Write, Description("Specifies the user account credentials to use to perform this task"), EmbeddedInstance("MSFT_Credential")] String DomainAdministratorCredential;
     [Write, Description("Specifies the authentication context type used when testing passwords"), ValueMap{"Default","Negotiate"},Values{"Default","Negotiate"}] String PasswordAuthentication;
-    [Write, Description("Indicates whether or not the user object should first tried to be restored from the recycle bin before creating a new computer object.")] Boolean RestoreFromRecycleBin;
+    [Write, Description("Indicates whether or not the user object should first tried to be restored from the recycle bin before creating a new user object.")] Boolean RestoreFromRecycleBin;
     [Read, Description("Returns the X.500 path of the object")] String DistinguishedName;
 };

--- a/DSCResources/MSFT_xADUser/MSFT_xADUser.schema.mof
+++ b/DSCResources/MSFT_xADUser/MSFT_xADUser.schema.mof
@@ -46,5 +46,6 @@ class MSFT_xADUser : OMI_BaseResource
     [Write, Description("Specifies the Active Directory Domain Services instance to use to perform the task.")] String DomainController;
     [Write, Description("Specifies the user account credentials to use to perform this task"), EmbeddedInstance("MSFT_Credential")] String DomainAdministratorCredential;
     [Write, Description("Specifies the authentication context type used when testing passwords"), ValueMap{"Default","Negotiate"},Values{"Default","Negotiate"}] String PasswordAuthentication;
+    [Write, Description("Indicates whether or not objects should be restored from recycle bin instead of recreating them")] Boolean RestoreFromRecycleBin;
     [Read, Description("Returns the X.500 path of the object")] String DistinguishedName;
 };

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The xADComputer DSC resource will manage computer accounts within Active Directo
 * **`[String]` Ensure**: Specifies whether the computer account is present or absent.
   * Valid values are 'Present' and 'Absent'.
   * It not specified, it defaults to 'Present'.
-* **`[Boolean]` RestoreFromRecycleBin** _(Write)_: Indicates whether or not the computer should be restored instead of created if possible.
+* **`[Boolean]` RestoreFromRecycleBin** _(Write)_: Indicates whether or not the computer object should first tried to be restored from the recycle bin before creating a new computer object.
 * **`[String]` DistinguishedName** _(Read)_: Returns the X.500 path of the computer object.
 * **`[String]` SID** _(Read)_: Returns the security identifier of the computer object.
 
@@ -321,6 +321,7 @@ The xADServicePrincipalName DSC resource will manage service principal names.
   * Assert-Module has been extended with a parameter ImportModule to also import the module ([issue #218](https://github.com/PowerShell/xActiveDirectory/issues/218)). [Jan-Hendrik Peters (@nyanhp)](https://github.com/nyanhp)
 * Changes to xADDomain
   * xADDomain makes use of new parameter ImportModule of Assert-Module in order to import the ADDSDeployment module ([issue #218](https://github.com/PowerShell/xActiveDirectory/issues/218)). [Jan-Hendrik Peters (@nyanhp)](https://github.com/nyanhp)
+* xADComputer, xADGroup, xADOrganizationalUnit and xADUser now support restoring from AD recycle bin ([Issue #221](https://github.com/PowerShell/xActiveDirectory/issues/211)). [Jan-Hendrik Peters (@nyanhp)](https://github.com/nyanhp)
 
 ### 2.20.0.0
 
@@ -328,7 +329,6 @@ The xADServicePrincipalName DSC resource will manage service principal names.
   * Changed MSFT_xADUser.schema.mof version to "1.0.0.0" to match other resources ([issue #190](https://github.com/PowerShell/xActiveDirectory/issues/190)). [thequietman44 (@thequietman44)](https://github.com/thequietman44)
   * Removed duplicated code from examples in README.md ([issue #198](https://github.com/PowerShell/xActiveDirectory/issues/198)). [thequietman44 (@thequietman44)](https://github.com/thequietman44)
   * xADDomain is now capable of setting the forest and domain functional level ([issue #187](https://github.com/PowerShell/xActiveDirectory/issues/187)). [Jan-Hendrik Peters (@nyanhp)](https://github.com/nyanhp)
-  * xADComputer, xADGroup, xADOrganizationalUnit and xADUser now support restoring from AD recycle bin ([Issue #221](https://github.com/PowerShell/xActiveDirectory/issues/211)). [Jan-Hendrik Peters (@nyanhp)](https://github.com/nyanhp)
 
 ### 2.19.0.0
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ The xADComputer DSC resource will manage computer accounts within Active Directo
 * **`[String]` Ensure**: Specifies whether the computer account is present or absent.
   * Valid values are 'Present' and 'Absent'.
   * It not specified, it defaults to 'Present'.
+* **`[Boolean]` RestoreFromRecycleBin** _(Write)_: Indicates whether or not the computer should be restored instead of created if possible.
 * **`[String]` DistinguishedName** _(Read)_: Returns the X.500 path of the computer object.
 * **`[String]` SID** _(Read)_: Returns the security identifier of the computer object.
 
@@ -181,10 +182,11 @@ The xADGroup DSC resource will manage groups within Active Directory.
 * **`[String]` Ensure** _(Write)_: Specifies whether the group is present or absent.
   * Valid values are 'Present' and 'Absent'.
   * It not specified, it defaults to 'Present'.
-* **`[String]` DomainController**: An existing Active Directory domain controller used to perform the operation.
+* **`[String]` DomainController** _(Write)_: An existing Active Directory domain controller used to perform the operation.
   * If not running on a domain controller, this is required.
-* **`[PSCredential]` Credential**: User account credentials used to perform the operation.
+* **`[PSCredential]` Credential** _(Write)_: User account credentials used to perform the operation.
   * If not running on a domain controller, this is required.
+* **`[Boolean]` RestoreFromRecycleBin** _(Write)_: Indicates whether or not the group should be restored instead of created if possible.
 
 ### **xADOrganizationalUnit**
 
@@ -196,6 +198,7 @@ The xADOrganizational Unit DSC resource will manage OUs within Active Directory.
 * **`[Boolean]` ProtectedFromAccidentalDeletion** _(Write)_: Valid values are $true and $false. If not specified, it defaults to $true.
 * **`[String]` Ensure** _(Write)_: Specifies whether the OU is present or absent. Valid values are 'Present' and 'Absent'. It not specified, it defaults to 'Present'.
 * **`[PSCredential]` Credential** _(Write)_: User account credentials used to perform the operation. Note: _if not running on a domain controller, this is required_.
+* **`[Boolean]` RestoreFromRecycleBin** _(Write)_: Indicates whether or not the OU should be restored instead of created if possible.
 
 ### **xADRecycleBin**
 
@@ -300,6 +303,7 @@ The xADServicePrincipalName DSC resource will manage service principal names.
   * If not specified, this value defaults to False.
 * **`[String]` PasswordAuthentication** _(Write)_: Specifies the authentication context used when testing users' passwords.
   * The 'Negotiate' option supports NTLM authentication - which may be required when testing users' passwords when Active Directory Certificate Services (ADCS) is deployed.
+* **`[Boolean]` RestoreFromRecycleBin** _(Write)_: Indicates whether or not the user should be restored instead of created if possible.
 * **`[String]` DistinguishedName** _(Read)_: The user distinguished name, returned with Get.
 
 ### **xWaitForADDomain**
@@ -324,6 +328,7 @@ The xADServicePrincipalName DSC resource will manage service principal names.
   * Changed MSFT_xADUser.schema.mof version to "1.0.0.0" to match other resources ([issue #190](https://github.com/PowerShell/xActiveDirectory/issues/190)). [thequietman44 (@thequietman44)](https://github.com/thequietman44)
   * Removed duplicated code from examples in README.md ([issue #198](https://github.com/PowerShell/xActiveDirectory/issues/198)). [thequietman44 (@thequietman44)](https://github.com/thequietman44)
   * xADDomain is now capable of setting the forest and domain functional level ([issue #187](https://github.com/PowerShell/xActiveDirectory/issues/187)). [Jan-Hendrik Peters (@nyanhp)](https://github.com/nyanhp)
+  * xADComputer, xADGroup, xADOrganizationalUnit and xADUser now support restoring from AD recycle bin ([Issue #221](https://github.com/PowerShell/xActiveDirectory/issues/211)). [Jan-Hendrik Peters (@nyanhp)](https://github.com/nyanhp)
 
 ### 2.19.0.0
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ The xADGroup DSC resource will manage groups within Active Directory.
   * If not running on a domain controller, this is required.
 * **`[PSCredential]` Credential** _(Write)_: User account credentials used to perform the operation.
   * If not running on a domain controller, this is required.
-* **`[Boolean]` RestoreFromRecycleBin** _(Write)_: Indicates whether or not the group should be restored instead of created if possible.
+* **`[Boolean]` RestoreFromRecycleBin** _(Write)_: Indicates whether or not the group object should first tried to be restored from the recycle bin before creating a new group object.
 
 ### **xADOrganizationalUnit**
 
@@ -198,7 +198,7 @@ The xADOrganizational Unit DSC resource will manage OUs within Active Directory.
 * **`[Boolean]` ProtectedFromAccidentalDeletion** _(Write)_: Valid values are $true and $false. If not specified, it defaults to $true.
 * **`[String]` Ensure** _(Write)_: Specifies whether the OU is present or absent. Valid values are 'Present' and 'Absent'. It not specified, it defaults to 'Present'.
 * **`[PSCredential]` Credential** _(Write)_: User account credentials used to perform the operation. Note: _if not running on a domain controller, this is required_.
-* **`[Boolean]` RestoreFromRecycleBin** _(Write)_: Indicates whether or not the OU should be restored instead of created if possible.
+* **`[Boolean]` RestoreFromRecycleBin** _(Write)_: Indicates whether or not the organizational unit should first tried to be restored from the recycle bin before creating a new organizational unit.
 
 ### **xADRecycleBin**
 
@@ -303,7 +303,7 @@ The xADServicePrincipalName DSC resource will manage service principal names.
   * If not specified, this value defaults to False.
 * **`[String]` PasswordAuthentication** _(Write)_: Specifies the authentication context used when testing users' passwords.
   * The 'Negotiate' option supports NTLM authentication - which may be required when testing users' passwords when Active Directory Certificate Services (ADCS) is deployed.
-* **`[Boolean]` RestoreFromRecycleBin** _(Write)_: Indicates whether or not the user should be restored instead of created if possible.
+* **`[Boolean]` RestoreFromRecycleBin** _(Write)_: Indicates whether or not the user object should first tried to be restored from the recycle bin before creating a new user object.
 * **`[String]` DistinguishedName** _(Read)_: The user distinguished name, returned with Get.
 
 ### **xWaitForADDomain**

--- a/Tests/Unit/MSFT_xADCommon.Tests.ps1
+++ b/Tests/Unit/MSFT_xADCommon.Tests.ps1
@@ -665,6 +665,12 @@ try
                 It 'Calls Get-ADObject as well as Restore-ADObject' {
                     Assert-VerifiableMock
                 }
+
+                It 'Throws Microsoft.ActiveDirectory.Management.ADException when object parent does not exist' {
+                    Mock -CommandName Restore-ADObject -MockWith { throw (New-Object -TypeName Microsoft.ActiveDirectory.Management.ADException)}
+
+                    {Restore-ADCommonObject -Identity $restoreIdentity -ObjectClass $restoreObjectClass} | Should -Throw
+                }
             }
             
             Context 'Objects not in recycle bin' {

--- a/Tests/Unit/MSFT_xADComputer.Tests.ps1
+++ b/Tests/Unit/MSFT_xADComputer.Tests.ps1
@@ -519,7 +519,7 @@ try
                 Assert-MockCalled -CommandName Remove-ADComputer -ParameterFilter { $Identity.ToString() -eq $testAbsentParams.ComputerName } -Scope It
             }
 
-            It 'Calls Restore-AdCommonObject when RestoreFromRecycleBin is used' {
+            It 'Should call Restore-AdCommonObject when RestoreFromRecycleBin is used' {
                 $restoreParam = $testPresentParams.Clone()
                 $restoreParam.RestoreFromRecycleBin = $true
                 $script:mockCounter = 0
@@ -536,16 +536,17 @@ try
                     ObjectClass = 'computer'
                 }}
                 Mock -CommandName New-ADComputer
-                Mock -CommandName Set-ADComputer -ParameterFilter { $true} # Had to overwrite parameter filter from an earlier test
+                 # Had to overwrite parameter filter from an earlier test
+                Mock -CommandName Set-ADComputer -ParameterFilter { $true }
 
                 Set-TargetResource @restoreParam
 
-                Assert-MockCalled -CommandName Restore-ADCommonObject -Scope It
+                Assert-MockCalled -CommandName Restore-ADCommonObject -Exactly -Times 1 -Scope It
                 Assert-MockCalled -CommandName New-ADComputer -Times 0 -Exactly -Scope It
-                Assert-MockCalled -CommandName Set-ADComputer -Scope It
+                Assert-MockCalled -CommandName Set-ADComputer -Exactly -Times 1 -Scope It
             }
 
-            It 'Calls New-ADComputer when RestoreFromRecycleBin is used and if no object was found in the recycle bin' {
+            It 'Should call New-ADComputer when RestoreFromRecycleBin is used and if no object was found in the recycle bin' {
                 $restoreParam = $testPresentParams.Clone()
                 $restoreParam.RestoreFromRecycleBin = $true
                 $script:mockCounter = 0
@@ -560,16 +561,17 @@ try
                 }
                 Mock -CommandName Restore-ADCommonObject
                 Mock -CommandName New-ADComputer
-                Mock -CommandName Set-ADComputer -ParameterFilter { $true} # Had to overwrite parameter filter from an earlier test
+                # Had to overwrite parameter filter from an earlier test
+                Mock -CommandName Set-ADComputer -ParameterFilter { $true }
 
                 Set-TargetResource @restoreParam
 
-                Assert-MockCalled -CommandName Restore-ADCommonObject -Scope It
-                Assert-MockCalled -CommandName New-ADComputer -Scope It
-                Assert-MockCalled -CommandName Set-ADComputer -Scope It
+                Assert-MockCalled -CommandName Restore-ADCommonObject -Exactly -Times 1 -Scope It
+                Assert-MockCalled -CommandName New-ADComputer -Exactly -Times 1 -Scope It
+                Assert-MockCalled -CommandName Set-ADComputer -Exactly -Times 1 -Scope It
             }
 
-            It 'Throws when object cannot be restored from recycle bin' {
+            It 'Should throw the correct error when object cannot be restored from recycle bin' {
                 $restoreParam = $testPresentParams.Clone()
                 $restoreParam.RestoreFromRecycleBin = $true
                 $script:mockCounter = 0
@@ -584,11 +586,12 @@ try
                 }
                 Mock -CommandName Restore-ADCommonObject -MockWith {throw (New-Object -TypeName System.InvalidOperationException)}
                 Mock -CommandName New-ADComputer
-                Mock -CommandName Set-ADComputer -ParameterFilter { $true} # Had to overwrite parameter filter from an earlier test
+                # Had to overwrite parameter filter from an earlier test
+                Mock -CommandName Set-ADComputer -ParameterFilter { $true }
 
-                {Set-TargetResource @restoreParam} | Should -Throw
+                {Set-TargetResource @restoreParam} | Should -Throw -ExceptionType ([System.InvalidOperationException])
 
-                Assert-MockCalled -CommandName Restore-ADCommonObject -Scope It
+                Assert-MockCalled -CommandName Restore-ADCommonObject -Scope It -Exactly -Times 1
                 Assert-MockCalled -CommandName New-ADComputer -Scope It -Exactly -Times 0
                 Assert-MockCalled -CommandName Set-ADComputer -Scope It -Exactly -Times 0
             }

--- a/Tests/Unit/MSFT_xADDomain.Tests.ps1
+++ b/Tests/Unit/MSFT_xADDomain.Tests.ps1
@@ -80,7 +80,7 @@ try
 
                 $result = Get-TargetResource @testDefaultParams -DomainName $correctDomainName;
 
-                Assert-MockCalled Assert-Module -ParameterFilter { $ModuleName -eq 'ADDSDeployment' } -Scope It
+                Assert-MockCalled -CommandName Assert-Module -ParameterFilter { $ModuleName -eq 'ADDSDeployment' } -Scope It
             }
 
             It 'Returns "System.Collections.Hashtable" object type' {
@@ -109,7 +109,7 @@ try
 
                 $result = Get-TargetResource @testDefaultParams -DomainName $correctDomainName;
 
-                Assert-MockCalled Get-ADDomain -ParameterFilter { $Credential -eq $null } -Scope It
+                Assert-MockCalled -CommandName Get-ADDomain -ParameterFilter { $Credential -eq $null } -Scope It
             }
 
             It 'Calls "Get-ADForest" without credentials if domain member' {
@@ -124,7 +124,7 @@ try
 
                 $result = Get-TargetResource @testDefaultParams -DomainName $correctDomainName;
 
-                Assert-MockCalled Get-ADForest -ParameterFilter { $Credential -eq $null } -Scope It
+                Assert-MockCalled -CommandName Get-ADForest -ParameterFilter { $Credential -eq $null } -Scope It
             }
 
             It 'Throws "Invalid credentials" when domain is available but authentication fails' {
@@ -311,7 +311,7 @@ try
 
                 Set-TargetResource @newForestParams;
 
-                Assert-MockCalled Install-ADDSForest -ParameterFilter  { $DomainName -eq $testDomainName } -Scope It
+                Assert-MockCalled -CommandName Install-ADDSForest -ParameterFilter  { $DomainName -eq $testDomainName } -Scope It
             }
 
             It 'Calls "Install-ADDSForest" with "SafemodeAdministratorPassword" when creating forest' {
@@ -319,7 +319,7 @@ try
 
                 Set-TargetResource @newForestParams;
 
-                Assert-MockCalled Install-ADDSForest -ParameterFilter { $SafemodeAdministratorPassword -eq $testSafemodePassword } -Scope It
+                Assert-MockCalled -CommandName Install-ADDSForest -ParameterFilter { $SafemodeAdministratorPassword -eq $testSafemodePassword } -Scope It
             }
 
             It 'Calls "Install-ADDSForest" with "DnsDelegationCredential" when creating forest, if specified' {
@@ -327,7 +327,7 @@ try
 
                 Set-TargetResource @newForestParams -DnsDelegationCredential $testDelegationCredential;
 
-                Assert-MockCalled Install-ADDSForest -ParameterFilter  { $DnsDelegationCredential -eq $testDelegationCredential } -Scope It
+                Assert-MockCalled -CommandName Install-ADDSForest -ParameterFilter  { $DnsDelegationCredential -eq $testDelegationCredential } -Scope It
             }
 
             It 'Calls "Install-ADDSForest" with "CreateDnsDelegation" when creating forest, if specified' {
@@ -335,7 +335,7 @@ try
 
                 Set-TargetResource @newForestParams -DnsDelegationCredential $testDelegationCredential;
 
-                Assert-MockCalled Install-ADDSForest -ParameterFilter  { $CreateDnsDelegation -eq $true } -Scope It
+                Assert-MockCalled -CommandName Install-ADDSForest -ParameterFilter  { $CreateDnsDelegation -eq $true } -Scope It
             }
 
             It 'Calls "Install-ADDSForest" with "DatabasePath" when creating forest, if specified' {
@@ -344,7 +344,7 @@ try
 
                 Set-TargetResource @newForestParams -DatabasePath $testPath;
 
-                Assert-MockCalled Install-ADDSForest -ParameterFilter { $DatabasePath -eq $testPath } -Scope It
+                Assert-MockCalled -CommandName Install-ADDSForest -ParameterFilter { $DatabasePath -eq $testPath } -Scope It
             }
 
             It 'Calls "Install-ADDSForest" with "LogPath" when creating forest, if specified' {
@@ -353,7 +353,7 @@ try
 
                 Set-TargetResource @newForestParams -LogPath $testPath;
 
-                Assert-MockCalled Install-ADDSForest -ParameterFilter { $LogPath -eq $testPath } -Scope It
+                Assert-MockCalled -CommandName Install-ADDSForest -ParameterFilter { $LogPath -eq $testPath } -Scope It
             }
 
             It 'Calls "Install-ADDSForest" with "SysvolPath" when creating forest, if specified' {
@@ -362,7 +362,7 @@ try
 
                 Set-TargetResource @newForestParams -SysvolPath $testPath;
 
-                Assert-MockCalled Install-ADDSForest -ParameterFilter { $SysvolPath -eq $testPath } -Scope It
+                Assert-MockCalled -CommandName Install-ADDSForest -ParameterFilter { $SysvolPath -eq $testPath } -Scope It
             }
 
             It 'Calls "Install-ADDSForest" with "DomainNetbiosName" when creating forest, if specified' {
@@ -370,7 +370,7 @@ try
 
                 Set-TargetResource @newForestParams -DomainNetBIOSName $testDomainNetBIOSNameName;
 
-                Assert-MockCalled Install-ADDSForest -ParameterFilter { $DomainNetbiosName -eq $testDomainNetBIOSNameName } -Scope It
+                Assert-MockCalled -CommandName Install-ADDSForest -ParameterFilter { $DomainNetbiosName -eq $testDomainNetBIOSNameName } -Scope It
             }
 
             It 'Calls "Install-ADDSForest" with "ForestMode" when creating forest, if specified' {
@@ -378,7 +378,7 @@ try
 
                 Set-TargetResource @newForestParams -ForestMode $testDomainForestMode;
 
-                Assert-MockCalled Install-ADDSForest -ParameterFilter { $ForestMode -eq $testDomainForestMode } -Scope It
+                Assert-MockCalled -CommandName Install-ADDSForest -ParameterFilter { $ForestMode -eq $testDomainForestMode } -Scope It
             }
 
             It 'Calls "Install-ADDSForest" with "DomainMode" when creating forest, if specified' {
@@ -386,7 +386,7 @@ try
 
                 Set-TargetResource @newForestParams -DomainMode $testDomainForestMode;
 
-                Assert-MockCalled Install-ADDSForest -ParameterFilter { $DomainMode -eq $testDomainForestMode } -Scope It
+                Assert-MockCalled -CommandName Install-ADDSForest -ParameterFilter { $DomainMode -eq $testDomainForestMode } -Scope It
             }
 
             #### ADDSDomain
@@ -396,7 +396,7 @@ try
 
                 Set-TargetResource @newDomainParams;
 
-                Assert-MockCalled Install-ADDSDomain -ParameterFilter  { $NewDomainName -eq $testDomainName } -Scope It
+                Assert-MockCalled -CommandName Install-ADDSDomain -ParameterFilter  { $NewDomainName -eq $testDomainName } -Scope It
             }
 
             It 'Calls "Install-ADDSDomain" with "ParentDomainName" when creating child domain' {
@@ -404,7 +404,7 @@ try
 
                 Set-TargetResource @newDomainParams;
 
-                Assert-MockCalled Install-ADDSDomain -ParameterFilter  { $ParentDomainName -eq $testParentDomainName } -Scope It
+                Assert-MockCalled -CommandName Install-ADDSDomain -ParameterFilter  { $ParentDomainName -eq $testParentDomainName } -Scope It
             }
 
             It 'Calls "Install-ADDSDomain" with "DomainType" when creating child domain' {
@@ -412,7 +412,7 @@ try
 
                 Set-TargetResource @newDomainParams;
 
-                Assert-MockCalled Install-ADDSDomain -ParameterFilter  { $DomainType -eq 'ChildDomain' } -Scope It
+                Assert-MockCalled -CommandName Install-ADDSDomain -ParameterFilter  { $DomainType -eq 'ChildDomain' } -Scope It
             }
 
             It 'Calls "Install-ADDSDomain" with "SafemodeAdministratorPassword" when creating child domain' {
@@ -420,7 +420,7 @@ try
 
                 Set-TargetResource @newDomainParams;
 
-                Assert-MockCalled Install-ADDSDomain -ParameterFilter { $SafemodeAdministratorPassword -eq $testSafemodePassword } -Scope It
+                Assert-MockCalled -CommandName Install-ADDSDomain -ParameterFilter { $SafemodeAdministratorPassword -eq $testSafemodePassword } -Scope It
             }
 
             It 'Calls "Install-ADDSDomain" with "Credential" when creating child domain' {
@@ -428,7 +428,7 @@ try
 
                 Set-TargetResource @newDomainParams;
 
-                Assert-MockCalled Install-ADDSDomain -ParameterFilter  { $ParentDomainName -eq $testParentDomainName } -Scope It
+                Assert-MockCalled -CommandName Install-ADDSDomain -ParameterFilter  { $ParentDomainName -eq $testParentDomainName } -Scope It
             }
 
             It 'Calls "Install-ADDSDomain" with "ParentDomainName" when creating child domain' {
@@ -436,7 +436,7 @@ try
 
                 Set-TargetResource @newDomainParams;
 
-                Assert-MockCalled Install-ADDSDomain -ParameterFilter  { $ParentDomainName -eq $testParentDomainName } -Scope It
+                Assert-MockCalled -CommandName Install-ADDSDomain -ParameterFilter  { $ParentDomainName -eq $testParentDomainName } -Scope It
             }
 
             It 'Calls "Install-ADDSDomain" with "DnsDelegationCredential" when creating child domain, if specified' {
@@ -444,7 +444,7 @@ try
 
                 Set-TargetResource @newDomainParams -DnsDelegationCredential $testDelegationCredential;
 
-                Assert-MockCalled Install-ADDSDomain -ParameterFilter  { $DnsDelegationCredential -eq $testDelegationCredential } -Scope It
+                Assert-MockCalled -CommandName Install-ADDSDomain -ParameterFilter  { $DnsDelegationCredential -eq $testDelegationCredential } -Scope It
             }
 
             It 'Calls "Install-ADDSDomain" with "CreateDnsDelegation" when creating child domain, if specified' {
@@ -452,7 +452,7 @@ try
 
                 Set-TargetResource @newDomainParams -DnsDelegationCredential $testDelegationCredential;
 
-                Assert-MockCalled Install-ADDSDomain -ParameterFilter  { $CreateDnsDelegation -eq $true } -Scope It
+                Assert-MockCalled -CommandName Install-ADDSDomain -ParameterFilter  { $CreateDnsDelegation -eq $true } -Scope It
             }
 
             It 'Calls "Install-ADDSDomain" with "DatabasePath" when creating child domain, if specified' {
@@ -461,7 +461,7 @@ try
 
                 Set-TargetResource @newDomainParams -DatabasePath $testPath;
 
-                Assert-MockCalled Install-ADDSDomain -ParameterFilter { $DatabasePath -eq $testPath } -Scope It
+                Assert-MockCalled -CommandName Install-ADDSDomain -ParameterFilter { $DatabasePath -eq $testPath } -Scope It
             }
 
             It 'Calls "Install-ADDSDomain" with "LogPath" when creating child domain, if specified' {
@@ -470,7 +470,7 @@ try
 
                 Set-TargetResource @newDomainParams -LogPath $testPath;
 
-                Assert-MockCalled Install-ADDSDomain -ParameterFilter { $LogPath -eq $testPath } -Scope It
+                Assert-MockCalled -CommandName Install-ADDSDomain -ParameterFilter { $LogPath -eq $testPath } -Scope It
             }
 
             It 'Calls "Install-ADDSDomain" with "SysvolPath" when creating child domain, if specified' {
@@ -479,7 +479,7 @@ try
 
                 Set-TargetResource @newDomainParams -SysvolPath $testPath;
 
-                Assert-MockCalled Install-ADDSDomain -ParameterFilter { $SysvolPath -eq $testPath } -Scope It
+                Assert-MockCalled -CommandName Install-ADDSDomain -ParameterFilter { $SysvolPath -eq $testPath } -Scope It
             }
 
             It 'Calls "Install-ADDSDomain" with "NewDomainNetbiosName" when creating child domain, if specified' {
@@ -487,7 +487,7 @@ try
 
                 Set-TargetResource @newDomainParams -DomainNetBIOSName $testDomainNetBIOSNameName;
 
-                Assert-MockCalled Install-ADDSDomain -ParameterFilter { $NewDomainNetbiosName -eq $testDomainNetBIOSNameName } -Scope It
+                Assert-MockCalled -CommandName Install-ADDSDomain -ParameterFilter { $NewDomainNetbiosName -eq $testDomainNetBIOSNameName } -Scope It
             }
 
             It 'Calls "Install-ADDSDomain" with "DomainMode" when creating child domain, if specified' {
@@ -495,7 +495,7 @@ try
 
                 Set-TargetResource @newDomainParams -DomainMode $testDomainForestMode;
 
-                Assert-MockCalled Install-ADDSDomain -ParameterFilter { $DomainMode -eq $testDomainForestMode } -Scope It
+                Assert-MockCalled -CommandName Install-ADDSDomain -ParameterFilter { $DomainMode -eq $testDomainForestMode } -Scope It
             }
         }
         #endregion

--- a/Tests/Unit/MSFT_xADDomainController.Tests.ps1
+++ b/Tests/Unit/MSFT_xADDomainController.Tests.ps1
@@ -184,7 +184,7 @@ try
 
             Set-TargetResource @testDefaultParams -DomainName $correctDomainName -SiteName $correctSiteName
 
-            Assert-MockCalled Install-ADDSDomainController -Times 1 -ParameterFilter { $SiteName -eq $correctSiteName } @commonAssertParams
+            Assert-MockCalled -CommandName Install-ADDSDomainController -Times 1 -ParameterFilter { $SiteName -eq $correctSiteName } @commonAssertParams
         }
 
         It 'Calls "Move-ADDirectoryServer" when "SiteName" does not match' {
@@ -200,7 +200,7 @@ try
 
             Set-TargetResource @testDefaultParams -DomainName $correctDomainName -SiteName $correctSiteName
 
-            Assert-MockCalled Move-ADDirectoryServer -Times 1 -ParameterFilter { $Site.ToString() -eq $correctSiteName } @commonAssertParams
+            Assert-MockCalled -CommandName Move-ADDirectoryServer -Times 1 -ParameterFilter { $Site.ToString() -eq $correctSiteName } @commonAssertParams
         }
 
         It 'Does not call "Move-ADDirectoryServer" when "SiteName" matches' {
@@ -215,7 +215,7 @@ try
 
             Set-TargetResource @testDefaultParams -DomainName $correctDomainName -SiteName $correctSiteName
 
-            Assert-MockCalled Move-ADDirectoryServer -Times 0 @commonAssertParams
+            Assert-MockCalled -CommandName Move-ADDirectoryServer -Times 0 @commonAssertParams
         }
 
         It 'Does not call "Move-ADDirectoryServer" when "SiteName" is not specified' {
@@ -230,7 +230,7 @@ try
 
             Set-TargetResource @testDefaultParams -DomainName $correctDomainName
 
-            Assert-MockCalled Move-ADDirectoryServer -Times 0 @commonAssertParams
+            Assert-MockCalled -CommandName Move-ADDirectoryServer -Times 0 @commonAssertParams
         }
     }
     #endregion

--- a/Tests/Unit/MSFT_xADDomainDefaultPasswordPolicy.Tests.ps1
+++ b/Tests/Unit/MSFT_xADDomainDefaultPasswordPolicy.Tests.ps1
@@ -65,7 +65,7 @@ try
 
                 $result = Get-TargetResource @testDefaultParams;
 
-                Assert-MockCalled Assert-Module -ParameterFilter { $ModuleName -eq 'ActiveDirectory' } -Scope It
+                Assert-MockCalled -CommandName Assert-Module -ParameterFilter { $ModuleName -eq 'ActiveDirectory' } -Scope It
             }
 
             It 'Returns "System.Collections.Hashtable" object type' {
@@ -81,7 +81,7 @@ try
 
                 $result = Get-TargetResource @testDefaultParams;
 
-                Assert-MockCalled Get-ADDefaultDomainPasswordPolicy -ParameterFilter { $Credential -eq $null } -Scope It
+                Assert-MockCalled -CommandName Get-ADDefaultDomainPasswordPolicy -ParameterFilter { $Credential -eq $null } -Scope It
             }
 
             It 'Calls "Get-ADDefaultDomainPasswordPolicy" with credentials when specified' {
@@ -89,7 +89,7 @@ try
 
                 $result = Get-TargetResource @testDefaultParams -Credential $testCredential;
 
-                Assert-MockCalled Get-ADDefaultDomainPasswordPolicy -ParameterFilter { $Credential -eq $testCredential } -Scope It
+                Assert-MockCalled -CommandName Get-ADDefaultDomainPasswordPolicy -ParameterFilter { $Credential -eq $testCredential } -Scope It
             }
 
             It 'Calls "Get-ADDefaultDomainPasswordPolicy" without server by default' {
@@ -97,7 +97,7 @@ try
 
                 $result = Get-TargetResource @testDefaultParams;
 
-                Assert-MockCalled Get-ADDefaultDomainPasswordPolicy -ParameterFilter { $Server -eq $null } -Scope It
+                Assert-MockCalled -CommandName Get-ADDefaultDomainPasswordPolicy -ParameterFilter { $Server -eq $null } -Scope It
             }
 
             It 'Calls "Get-ADDefaultDomainPasswordPolicy" with server when specified' {
@@ -105,7 +105,7 @@ try
 
                 $result = Get-TargetResource @testDefaultParams -DomainController $testDomainController;
 
-                Assert-MockCalled Get-ADDefaultDomainPasswordPolicy -ParameterFilter { $Server -eq $testDomainController } -Scope It
+                Assert-MockCalled -CommandName Get-ADDefaultDomainPasswordPolicy -ParameterFilter { $Server -eq $testDomainController } -Scope It
             }
 
         }
@@ -147,7 +147,7 @@ try
 
                 $result = Test-TargetResource @testDefaultParams -Credential $testCredential;
 
-                Assert-MockCalled Get-TargetResource -ParameterFilter { $Credential -eq $testCredential } -Scope It
+                Assert-MockCalled -CommandName Get-TargetResource -ParameterFilter { $Credential -eq $testCredential } -Scope It
             }
 
             It 'Calls "Get-TargetResource" with "DomainController" parameter when specified' {
@@ -155,7 +155,7 @@ try
 
                 $result = Test-TargetResource @testDefaultParams -DomainController $testDomainController;
 
-                Assert-MockCalled Get-TargetResource -ParameterFilter { $DomainController -eq $testDomainController } -Scope It
+                Assert-MockCalled -CommandName Get-TargetResource -ParameterFilter { $DomainController -eq $testDomainController } -Scope It
             }
 
             foreach ($propertyName in $stubPasswordPolicy.Keys)
@@ -226,7 +226,7 @@ try
 
                 $result = Set-TargetResource @testDefaultParams;
 
-                Assert-MockCalled Assert-Module -ParameterFilter { $ModuleName -eq 'ActiveDirectory' } -Scope It
+                Assert-MockCalled -CommandName Assert-Module -ParameterFilter { $ModuleName -eq 'ActiveDirectory' } -Scope It
             }
 
             It 'Calls "Set-ADDefaultDomainPasswordPolicy" without "Credential" parameter by default' {
@@ -234,7 +234,7 @@ try
 
                 $result = Set-TargetResource @testDefaultParams;
 
-                Assert-MockCalled Set-ADDefaultDomainPasswordPolicy -ParameterFilter { $Credential -eq $null } -Scope It
+                Assert-MockCalled -CommandName Set-ADDefaultDomainPasswordPolicy -ParameterFilter { $Credential -eq $null } -Scope It
             }
 
             It 'Calls "Set-ADDefaultDomainPasswordPolicy" with "Credential" parameter when specified' {
@@ -242,7 +242,7 @@ try
 
                 $result = Set-TargetResource @testDefaultParams -Credential $testCredential;
 
-                Assert-MockCalled Set-ADDefaultDomainPasswordPolicy -ParameterFilter { $Credential -eq $testCredential } -Scope It
+                Assert-MockCalled -CommandName Set-ADDefaultDomainPasswordPolicy -ParameterFilter { $Credential -eq $testCredential } -Scope It
             }
 
             It 'Calls "Set-ADDefaultDomainPasswordPolicy" without "Server" parameter by default' {
@@ -250,7 +250,7 @@ try
 
                 $result = Set-TargetResource @testDefaultParams;
 
-                Assert-MockCalled Set-ADDefaultDomainPasswordPolicy -ParameterFilter { $Server -eq $null } -Scope It
+                Assert-MockCalled -CommandName Set-ADDefaultDomainPasswordPolicy -ParameterFilter { $Server -eq $null } -Scope It
             }
 
             It 'Calls "Set-ADDefaultDomainPasswordPolicy" with "Server" parameter when specified' {
@@ -258,7 +258,7 @@ try
 
                 $result = Set-TargetResource @testDefaultParams -DomainController $testDomainController;
 
-                Assert-MockCalled Set-ADDefaultDomainPasswordPolicy -ParameterFilter { $Server -eq $testDomainController } -Scope It
+                Assert-MockCalled -CommandName Set-ADDefaultDomainPasswordPolicy -ParameterFilter { $Server -eq $testDomainController } -Scope It
             }
 
             foreach ($propertyName in $stubPasswordPolicy.Keys)
@@ -270,7 +270,7 @@ try
 
                     $result = Set-TargetResource @propertyDefaultParams;
 
-                    Assert-MockCalled Set-ADDefaultDomainPasswordPolicy -ParameterFilter { $PSBoundParameters.ContainsKey($propertyName) } -Scope It
+                    Assert-MockCalled -CommandName Set-ADDefaultDomainPasswordPolicy -ParameterFilter { $PSBoundParameters.ContainsKey($propertyName) } -Scope It
                 }
 
             } #end foreach property name

--- a/Tests/Unit/MSFT_xADGroup.Tests.ps1
+++ b/Tests/Unit/MSFT_xADGroup.Tests.ps1
@@ -91,7 +91,7 @@ try
 
                 $result = Get-TargetResource @testPresentParams; # -DomainName $correctDomainName;
 
-                Assert-MockCalled Assert-Module -ParameterFilter { $ModuleName -eq 'ActiveDirectory' } -Scope It
+                Assert-MockCalled -CommandName Assert-Module -ParameterFilter { $ModuleName -eq 'ActiveDirectory' } -Scope It
             }
 
             It "Returns 'Ensure' is 'Present' when group exists" {
@@ -114,7 +114,7 @@ try
 
                 Get-TargetResource @testPresentParams -DomainController $testDomainController;
 
-                Assert-MockCalled Get-ADGroup -ParameterFilter { $Server -eq $testDomainController } -Scope It
+                Assert-MockCalled -CommandName Get-ADGroup -ParameterFilter { $Server -eq $testDomainController } -Scope It
             }
 
             It "Calls 'Get-ADGroup' with 'Credential' parameter when specified" {
@@ -123,7 +123,7 @@ try
 
                 Get-TargetResource @testPresentParams -Credential $testCredentials;
 
-                Assert-MockCalled Get-ADGroup -ParameterFilter { $Credential -eq $testCredentials } -Scope It
+                Assert-MockCalled -CommandName Get-ADGroup -ParameterFilter { $Credential -eq $testCredentials } -Scope It
             }
 
             It "Calls 'Get-ADGroupMember' with 'Server' parameter when 'DomainController' specified" {
@@ -132,7 +132,7 @@ try
 
                 Get-TargetResource @testPresentParams -DomainController $testDomainController;
 
-                Assert-MockCalled Get-ADGroupMember -ParameterFilter { $Server -eq $testDomainController } -Scope It
+                Assert-MockCalled -CommandName Get-ADGroupMember -ParameterFilter { $Server -eq $testDomainController } -Scope It
             }
 
             It "Calls 'Get-ADGroupMember' with 'Credential' parameter when specified" {
@@ -141,7 +141,7 @@ try
 
                 Get-TargetResource @testPresentParams -Credential $testCredentials;
 
-                Assert-MockCalled Get-ADGroupMember -ParameterFilter { $Credential -eq $testCredentials } -Scope It
+                Assert-MockCalled -CommandName Get-ADGroupMember -ParameterFilter { $Credential -eq $testCredentials } -Scope It
             }
 
         }
@@ -322,13 +322,13 @@ try
             Mock -CommandName Assert-Module -ParameterFilter { $ModuleName -eq 'ActiveDirectory' }
 
             It "Calls 'New-ADGroup' when 'Ensure' is 'Present' and the group does not exist" {
-                Mock -CommandName Get-ADGroup { throw New-Object Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException }
+                Mock -CommandName Get-ADGroup -MockWith { throw New-Object Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException }
                 Mock -CommandName Set-ADGroup
-                Mock -CommandName New-ADGroup { return [PSCustomObject] $fakeADGroup; }
+                Mock -CommandName New-ADGroup -MockWith { return [PSCustomObject] $fakeADGroup; }
 
                 Set-TargetResource @testPresentParams;
 
-                Assert-MockCalled New-ADGroup -Scope It
+                Assert-MockCalled -CommandName New-ADGroup -Scope It
             }
 
             $testProperties = @{
@@ -341,7 +341,7 @@ try
                 It "Calls 'Set-ADGroup' when 'Ensure' is 'Present' and '$property' is specified" {
                     Mock -CommandName Set-ADGroup
                     Mock -CommandName Get-ADGroupMember
-                    Mock -CommandName Get-ADGroup {
+                    Mock -CommandName Get-ADGroup -MockWith {
                         $duffADGroup = $fakeADGroup.Clone();
                         $duffADGroup[$property] = $testProperties.$property;
                         return $duffADGroup;
@@ -349,14 +349,14 @@ try
 
                     Set-TargetResource @testPresentParams;
 
-                    Assert-MockCalled Set-ADGroup -Scope It -Exactly 1;
+                    Assert-MockCalled -CommandName Set-ADGroup -Scope It -Exactly 1;
                 }
             }
 
             It "Calls 'Set-ADGroup' when 'Ensure' is 'Present' and 'Category' is specified" {
                 Mock -CommandName Set-ADGroup -ParameterFilter { $GroupCategory -eq $testPresentParams.Category }
                 Mock -CommandName Get-ADGroupMember
-                Mock -CommandName Get-ADGroup {
+                Mock -CommandName Get-ADGroup -MockWith {
                     $duffADGroup = $fakeADGroup.Clone();
                     $duffADGroup['GroupCategory'] = 'Distribution';
                     return $duffADGroup;
@@ -364,7 +364,7 @@ try
 
                 Set-TargetResource @testPresentParams;
 
-                Assert-MockCalled Set-ADGroup -ParameterFilter { $GroupCategory -eq $testPresentParams.Category } -Scope It -Exactly 1;
+                Assert-MockCalled -CommandName Set-ADGroup -ParameterFilter { $GroupCategory -eq $testPresentParams.Category } -Scope It -Exactly 1;
             }
 
             It "Calls 'Set-ADGroup' when 'Ensure' is 'Present' and 'Notes' is specified" {
@@ -378,13 +378,13 @@ try
 
                 Set-TargetResource @testPresentParams;
 
-                Assert-MockCalled Set-ADGroup -ParameterFilter { $Replace -ne $null } -Scope It -Exactly 1;
+                Assert-MockCalled -CommandName Set-ADGroup -ParameterFilter { $Replace -ne $null } -Scope It -Exactly 1;
             }
 
             It "Calls 'Set-ADGroup' twice when 'Ensure' is 'Present', the group exists but the 'Scope' has changed" {
                 Mock -CommandName Set-ADGroup
                 Mock -CommandName Get-ADGroupMember
-                Mock -CommandName Get-ADGroup {
+                Mock -CommandName Get-ADGroup -MockWith {
                     $duffADGroup = $fakeADGroup.Clone();
                     $duffADGroup['GroupScope'] = 'DomainLocal';
                     return $duffADGroup;
@@ -392,36 +392,36 @@ try
 
                 Set-TargetResource @testPresentParams;
 
-                Assert-MockCalled Set-ADGroup -Scope It -Exactly 2;
+                Assert-MockCalled -CommandName Set-ADGroup -Scope It -Exactly 2;
             }
 
             It "Adds group members when 'Ensure' is 'Present', the group exists and 'Members' are specified" {
-                Mock -CommandName Get-ADGroup { throw New-Object Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException }
+                Mock -CommandName Get-ADGroup -MockWith { throw New-Object Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException }
                 Mock -CommandName Set-ADGroup
                 Mock -CommandName Add-ADGroupMember
-                Mock -CommandName New-ADGroup { return [PSCustomObject] $fakeADGroup; }
+                Mock -CommandName New-ADGroup -MockWith { return [PSCustomObject] $fakeADGroup; }
 
                 Set-TargetResource @testPresentParams -Members @($fakeADUser1.SamAccountName, $fakeADUser2.SamAccountName);
 
-                Assert-MockCalled Add-ADGroupMember -Scope It
+                Assert-MockCalled -CommandName Add-ADGroupMember -Scope It
             }
 
             It "Adds group members when 'Ensure' is 'Present', the group exists and 'MembersToInclude' are specified" {
-                Mock -CommandName Get-ADGroup { throw New-Object Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException }
+                Mock -CommandName Get-ADGroup -MockWith { throw New-Object Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException }
                 Mock -CommandName Set-ADGroup
                 Mock -CommandName Add-ADGroupMember
-                Mock -CommandName New-ADGroup { return [PSCustomObject] $fakeADGroup; }
+                Mock -CommandName New-ADGroup -MockWith { return [PSCustomObject] $fakeADGroup; }
 
                 Set-TargetResource @testPresentParams -MembersToInclude @($fakeADUser1.SamAccountName, $fakeADUser2.SamAccountName);
 
-                Assert-MockCalled Add-ADGroupMember -Scope It
+                Assert-MockCalled -CommandName Add-ADGroupMember -Scope It
             }
 
             It "Moves group when 'Ensure' is 'Present', the group exists but the 'Path' has changed" {
                 Mock -CommandName Set-ADGroup
                 Mock -CommandName Get-ADGroupMember
                 Mock -CommandName Move-ADObject
-                Mock -CommandName Get-ADGroup {
+                Mock -CommandName Get-ADGroup -MockWith {
                     $duffADGroup = $fakeADGroup.Clone();
                     $duffADGroup['DistinguishedName'] = "CN=$($testPresentParams.GroupName),OU=WrongPath,DC=contoso,DC=com";
                     return $duffADGroup;
@@ -429,90 +429,90 @@ try
 
                 Set-TargetResource @testPresentParams;
 
-                Assert-MockCalled Move-ADObject -Scope It
+                Assert-MockCalled -CommandName Move-ADObject -Scope It
             }
 
             It "Resets group membership when 'Ensure' is 'Present' and 'Members' is incorrect" {
-                Mock -CommandName Get-ADGroup { return [PSCustomObject] $fakeADGroup; }
+                Mock -CommandName Get-ADGroup -MockWith { return [PSCustomObject] $fakeADGroup; }
                 Mock -CommandName Set-ADGroup
-                Mock -CommandName Get-ADGroupMember { return @($fakeADUser1, $fakeADUser2); }
+                Mock -CommandName Get-ADGroupMember -MockWith { return @($fakeADUser1, $fakeADUser2); }
                 Mock -CommandName Add-ADGroupMember
                 Mock -CommandName Remove-ADGroupMember
 
                 Set-TargetResource @testPresentParams -Members $fakeADuser1.SamAccountName;
 
-                Assert-MockCalled Remove-ADGroupMember -Scope It -Exactly 1;
-                Assert-MockCalled Add-ADGroupMember -Scope It -Exactly 1;
+                Assert-MockCalled -CommandName Remove-ADGroupMember -Scope It -Exactly 1;
+                Assert-MockCalled -CommandName Add-ADGroupMember -Scope It -Exactly 1;
             }
 
             It "Does not reset group membership when 'Ensure' is 'Present' and existing group is empty" {
-                Mock -CommandName Get-ADGroup { return [PSCustomObject] $fakeADGroup; }
+                Mock -CommandName Get-ADGroup -MockWith { return [PSCustomObject] $fakeADGroup; }
                 Mock -CommandName Set-ADGroup
                 Mock -CommandName Get-ADGroupMember
                 Mock -CommandName Remove-ADGroupMember
 
                 Set-TargetResource @testPresentParams -MembersToExclude $fakeADuser1.SamAccountName;
 
-                Assert-MockCalled Remove-ADGroupMember -Scope It -Exactly 0;
+                Assert-MockCalled -CommandName Remove-ADGroupMember -Scope It -Exactly 0;
             }
 
             It "Removes members when 'Ensure' is 'Present' and 'MembersToExclude' is incorrect" {
-                Mock -CommandName Get-ADGroup { return [PSCustomObject] $fakeADGroup; }
+                Mock -CommandName Get-ADGroup -MockWith { return [PSCustomObject] $fakeADGroup; }
                 Mock -CommandName Set-ADGroup
-                Mock -CommandName Get-ADGroupMember { return @($fakeADUser1, $fakeADUser2); }
+                Mock -CommandName Get-ADGroupMember -MockWith { return @($fakeADUser1, $fakeADUser2); }
                 Mock -CommandName Remove-ADGroupMember
 
                 Set-TargetResource @testPresentParams -MembersToExclude $fakeADuser1.SamAccountName;
 
-                Assert-MockCalled Remove-ADGroupMember -Scope It -Exactly 1;
+                Assert-MockCalled -CommandName Remove-ADGroupMember -Scope It -Exactly 1;
             }
 
             It "Adds members when 'Ensure' is 'Present' and 'MembersToInclude' is incorrect" {
-                Mock -CommandName Get-ADGroup { return [PSCustomObject] $fakeADGroup; }
+                Mock -CommandName Get-ADGroup -MockWith { return [PSCustomObject] $fakeADGroup; }
                 Mock -CommandName Set-ADGroup
-                Mock -CommandName Get-ADGroupMember { return @($fakeADUser1, $fakeADUser2); }
+                Mock -CommandName Get-ADGroupMember -MockWith { return @($fakeADUser1, $fakeADUser2); }
                 Mock -CommandName Add-ADGroupMember
 
                 Set-TargetResource @testPresentParams -MembersToInclude $fakeADuser3.SamAccountName;
 
-                Assert-MockCalled Add-ADGroupMember -Scope It -Exactly 1;
+                Assert-MockCalled -CommandName Add-ADGroupMember -Scope It -Exactly 1;
             }
 
             It "Removes group when 'Ensure' is 'Absent' and group exists" {
-                Mock -CommandName Get-ADGroup { return $fakeADGroup; }
+                Mock -CommandName Get-ADGroup -MockWith { return $fakeADGroup; }
                 Mock -CommandName Remove-ADGroup
 
                 Set-TargetResource @testAbsentParams;
 
-                Assert-MockCalled Remove-ADGroup -Scope It
+                Assert-MockCalled -CommandName Remove-ADGroup -Scope It
             }
 
             It "Calls 'Set-ADGroup' with credentials when 'Ensure' is 'Present' and the group exists (#106)" {
-                Mock -CommandName Get-ADGroup { return $fakeADGroup; }
-                Mock -CommandName New-ADGroup { return [PSCustomObject] $fakeADGroup; }
+                Mock -CommandName Get-ADGroup -MockWith { return $fakeADGroup; }
+                Mock -CommandName New-ADGroup -MockWith { return [PSCustomObject] $fakeADGroup; }
                 Mock -CommandName Get-ADGroupMember
                 Mock -CommandName Set-ADGroup -ParameterFilter { $Credential -eq $testCredentials }
 
                 Set-TargetResource @testPresentParams -Credential $testCredentials;
 
-                Assert-MockCalled Set-ADGroup -ParameterFilter { $Credential -eq $testCredentials } -Scope It
+                Assert-MockCalled -CommandName Set-ADGroup -ParameterFilter { $Credential -eq $testCredentials } -Scope It
             }
 
             It "Calls 'Set-ADGroup' with credentials when 'Ensure' is 'Present' and the group does not exist  (#106)" {
-                Mock -CommandName Get-ADGroup { throw New-Object Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException }
+                Mock -CommandName Get-ADGroup -MockWith { throw New-Object Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException }
                 Mock -CommandName Set-ADGroup -ParameterFilter { $Credential -eq $testCredentials } 
-                Mock -CommandName New-ADGroup { return [PSCustomObject] $fakeADGroup; }
+                Mock -CommandName New-ADGroup -MockWith { return [PSCustomObject] $fakeADGroup; }
 
                 Set-TargetResource @testPresentParams -Credential $testCredentials;
 
-                Assert-MockCalled Set-ADGroup -ParameterFilter { $Credential -eq $testCredentials } -Scope It
+                Assert-MockCalled -CommandName Set-ADGroup -ParameterFilter { $Credential -eq $testCredentials } -Scope It
             }
 
             It "Calls 'Move-ADObject' with credentials when specified (#106)" {
                 Mock -CommandName Set-ADGroup
                 Mock -CommandName Get-ADGroupMember
                 Mock -CommandName Move-ADObject -ParameterFilter { $Credential -eq $testCredentials }
-                Mock -CommandName Get-ADGroup {
+                Mock -CommandName Get-ADGroup -MockWith {
                     $duffADGroup = $fakeADGroup.Clone();
                     $duffADGroup['DistinguishedName'] = "CN=$($testPresentParams.GroupName),OU=WrongPath,DC=contoso,DC=com";
                     return $duffADGroup;
@@ -520,7 +520,7 @@ try
 
                 Set-TargetResource @testPresentParams -Credential $testCredentials;
 
-                Assert-MockCalled Move-ADObject -ParameterFilter { $Credential -eq $testCredentials } -Scope It
+                Assert-MockCalled -CommandName Move-ADObject -ParameterFilter { $Credential -eq $testCredentials } -Scope It
             }
 
 
@@ -531,7 +531,7 @@ try
                 $fakeADUniversalGroup = $fakeADGroup.Clone()
                 $fakeADUniversalGroup['GroupScope'] = 'Universal'
 
-                Mock -CommandName Get-ADGroup { return [PSCustomObject] $fakeADUniversalGroup }
+                Mock -CommandName Get-ADGroup -MockWith { return [PSCustomObject] $fakeADUniversalGroup }
                 Mock -CommandName Set-ADGroup -ParameterFilter { $Identity -eq $fakeADUniversalGroup.Identity -and -not $PSBoundParameters.ContainsKey('GroupScope') }
                 Mock -CommandName Add-ADGroupMember
 
@@ -547,7 +547,7 @@ try
                 $fakeADUniversalGroup = $fakeADGroup.Clone()
                 $fakeADUniversalGroup['GroupCategory'] = 'Distribution'
 
-                Mock -CommandName Get-ADGroup { return [PSCustomObject] $fakeADUniversalGroup }
+                Mock -CommandName Get-ADGroup -MockWith { return [PSCustomObject] $fakeADUniversalGroup }
                 Mock -CommandName Set-ADGroup -ParameterFilter { $Identity -eq $fakeADUniversalGroup.Identity -and -not $PSBoundParameters.ContainsKey('GroupCategory') }
                 Mock -CommandName Add-ADGroupMember
 
@@ -563,7 +563,7 @@ try
                 $fakeADUniversalGroup = $fakeADGroup.Clone()
                 $fakeADUniversalGroup['GroupScope'] = 'Universal'
 
-                Mock -CommandName Get-ADGroup { return [PSCustomObject] $fakeADUniversalGroup }
+                Mock -CommandName Get-ADGroup -MockWith { return [PSCustomObject] $fakeADUniversalGroup }
                 Mock -CommandName Set-ADGroup -ParameterFilter { $Identity -eq $fakeADUniversalGroup.Identity -and -not $PSBoundParameters.ContainsKey('GroupScope') }
                 Mock -CommandName Add-ADGroupMember
 
@@ -578,7 +578,7 @@ try
                 $fakeADUniversalGroup = $fakeADGroup.Clone()
                 $fakeADUniversalGroup['GroupCategory'] = 'Distribution'
 
-                Mock -CommandName Get-ADGroup { return [PSCustomObject] $fakeADUniversalGroup }
+                Mock -CommandName Get-ADGroup -MockWith { return [PSCustomObject] $fakeADUniversalGroup }
                 Mock -CommandName Set-ADGroup -ParameterFilter { $Identity -eq $fakeADUniversalGroup.Identity -and -not $PSBoundParameters.ContainsKey('GroupScope') }
                 Mock -CommandName Add-ADGroupMember
 
@@ -586,6 +586,49 @@ try
                 $universalGroupInCompliance | Should Be $true
             }
 
+            It "Calls Restore-AdCommonObject when RestoreFromRecycleBin is used" {
+                $restoreParam = $testPresentParams.Clone()
+                $restoreParam.RestoreFromRecycleBin = $true
+                Mock -CommandName Get-ADGroup -MockWith { throw New-Object Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException }
+                Mock -CommandName Set-ADGroup
+                Mock -CommandName New-ADGroup -MockWith { return [PSCustomObject] $fakeADGroup; }
+                Mock -CommandName Restore-ADCommonObject -MockWith { return [PSCustomObject] $fakeADGroup;}
+
+                Set-TargetResource @restoreParam;
+
+                Assert-MockCalled -CommandName Restore-AdCommonObject -Scope It
+                Assert-MockCalled -CommandName New-ADGroup -Scope It -Exactly -Times 0
+                Assert-MockCalled -CommandName Set-ADGroup -Scope It
+            }
+
+            It "Calls New-ADGroup when RestoreFromRecycleBin is used and if no object was found in the recycle bin" {
+                $restoreParam = $testPresentParams.Clone()
+                $restoreParam.RestoreFromRecycleBin = $true
+                Mock -CommandName Get-ADGroup -MockWith { throw New-Object Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException }
+                Mock -CommandName Set-ADGroup
+                Mock -CommandName New-ADGroup -MockWith { return [PSCustomObject] $fakeADGroup; }
+                Mock -CommandName Restore-ADCommonObject
+
+                Set-TargetResource @restoreParam;
+
+                Assert-MockCalled -CommandName Restore-AdCommonObject -Scope It
+                Assert-MockCalled -CommandName New-ADGroup -Scope It
+            }
+
+            It "Throws if the object cannot be restored" {
+                $restoreParam = $testPresentParams.Clone()
+                $restoreParam.RestoreFromRecycleBin = $true
+                Mock -CommandName Get-ADGroup -MockWith { throw New-Object Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException }
+                Mock -CommandName Set-ADGroup
+                Mock -CommandName New-ADGroup -MockWith { return [PSCustomObject] $fakeADGroup; }
+                Mock -CommandName Restore-ADCommonObject -MockWith { throw (New-Object -TypeName System.InvalidOperationException)}
+
+                {Set-TargetResource @restoreParam;} | Should -Throw
+
+                Assert-MockCalled -CommandName Restore-AdCommonObject -Scope It
+                Assert-MockCalled -CommandName New-ADGroup -Scope It -Exactly -Times 0
+                Assert-MockCalled -CommandName Set-ADGroup -Scope It -Exactly -Times 0
+            }
         }
         #end region
 

--- a/Tests/Unit/MSFT_xADOrganizationalUnit.Tests.ps1
+++ b/Tests/Unit/MSFT_xADOrganizationalUnit.Tests.ps1
@@ -194,7 +194,7 @@ try
                 Mock -CommandName New-ADOrganizationalUnit -ParameterFilter { $Name -eq $testPresentParams.Name }
 
                 Set-TargetResource @testPresentParams
-                Assert-MockCalled New-ADOrganizationalUnit -ParameterFilter { $Name -eq $testPresentParams.Name } -Scope It
+                Assert-MockCalled -CommandName New-ADOrganizationalUnit -ParameterFilter { $Name -eq $testPresentParams.Name } -Scope It
             }
 
             It 'Calls "New-ADOrganizationalUnit" with credentials when specified' {
@@ -203,7 +203,7 @@ try
                 Mock -CommandName New-ADOrganizationalUnit -ParameterFilter { $Credential -eq $testCredential }
 
                 Set-TargetResource @testPresentParams -Credential $testCredential
-                Assert-MockCalled New-ADOrganizationalUnit -ParameterFilter { $Credential -eq $testCredential } -Scope It
+                Assert-MockCalled -CommandName New-ADOrganizationalUnit -ParameterFilter { $Credential -eq $testCredential } -Scope It
             }
 
             It 'Calls "Set-ADOrganizationalUnit" when "Ensure" = "Present" and OU does exist' {
@@ -212,7 +212,7 @@ try
                 Mock -CommandName Set-ADOrganizationalUnit
 
                 Set-TargetResource @testPresentParams
-                Assert-MockCalled Set-ADOrganizationalUnit -Scope It
+                Assert-MockCalled -CommandName Set-ADOrganizationalUnit -Scope It
             }
 
             It 'Calls "Set-ADOrganizationalUnit" with credentials when specified' {
@@ -221,7 +221,7 @@ try
                 Mock -CommandName Set-ADOrganizationalUnit -ParameterFilter { $Credential -eq $testCredential }
 
                 Set-TargetResource @testPresentParams -Credential $testCredential
-                Assert-MockCalled Set-ADOrganizationalUnit -ParameterFilter { $Credential -eq $testCredential } -Scope It
+                Assert-MockCalled -CommandName Set-ADOrganizationalUnit -ParameterFilter { $Credential -eq $testCredential } -Scope It
             }
 
             It 'Calls "Remove-ADOrganizationalUnit" when "Ensure" = "Absent" and OU does exist but is unprotected' {
@@ -234,7 +234,7 @@ try
                 Mock -CommandName Remove-ADOrganizationalUnit
 
                 Set-TargetResource @testAbsentParams
-                Assert-MockCalled Remove-ADOrganizationalUnit -Scope It
+                Assert-MockCalled -CommandName Remove-ADOrganizationalUnit -Scope It
             }
 
             It 'Calls "Remove-ADOrganizationalUnit" when "Ensure" = "Absent" and OU does exist and is protected' {
@@ -243,7 +243,7 @@ try
                 Mock -CommandName Remove-ADOrganizationalUnit
 
                 Set-TargetResource @testAbsentParams
-                Assert-MockCalled Remove-ADOrganizationalUnit -Scope It
+                Assert-MockCalled -CommandName Remove-ADOrganizationalUnit -Scope It
             }
 
             It 'Calls "Remove-ADOrganizationalUnit" with credentials when specified' {
@@ -252,7 +252,7 @@ try
                 Mock -CommandName Remove-ADOrganizationalUnit -ParameterFilter { $Credential -eq $testCredential }
 
                 Set-TargetResource @testAbsentParams -Credential $testCredential
-                Assert-MockCalled Remove-ADOrganizationalUnit -ParameterFilter { $Credential -eq $testCredential } -Scope It
+                Assert-MockCalled -CommandName Remove-ADOrganizationalUnit -ParameterFilter { $Credential -eq $testCredential } -Scope It
             }
 
             It 'Calls "Set-ADOrganizationalUnit" when "Ensure" = "Absent", OU does exist but is protected' {
@@ -262,7 +262,7 @@ try
                 Mock -CommandName Set-ADOrganizationalUnit
 
                 Set-TargetResource @testAbsentParams
-                Assert-MockCalled Set-ADOrganizationalUnit -Scope It
+                Assert-MockCalled -CommandName Set-ADOrganizationalUnit -Scope It
             }
 
             It 'Does not call "Set-ADOrganizationalUnit" when "Ensure" = "Absent", OU does exist but is unprotected' {
@@ -276,7 +276,7 @@ try
                 Mock -CommandName Set-ADOrganizationalUnit
 
                 Set-TargetResource @testAbsentParams
-                Assert-MockCalled Set-ADOrganizationalUnit -Scope It -Exactly 0
+                Assert-MockCalled -CommandName Set-ADOrganizationalUnit -Scope It -Exactly 0
             }
 
         }

--- a/Tests/Unit/MSFT_xADOrganizationalUnit.Tests.ps1
+++ b/Tests/Unit/MSFT_xADOrganizationalUnit.Tests.ps1
@@ -283,11 +283,12 @@ try
                 $restoreParam = $testPresentParams.Clone()
                 $restoreParam.RestoreFromRecycleBin = $true
                 Mock -CommandName Get-TargetResource -MockWith { return @{Ensure = 'Absent'}}
-                Mock -CommandName Restore-ADCommonObject
+                Mock -CommandName Restore-ADCommonObject -MockWith { return [PSCustomObject] $protectedFakeAdOu }
 
                 Set-TargetResource @restoreParam;
 
                 Assert-MockCalled -CommandName Restore-AdCommonObject -Scope It
+                Assert-MockCalled -CommandName New-ADOrganizationalUnit -Scope It -Exactly -Times 0
             }
 
             It "Calls New-ADOrganizationalUnit when RestoreFromRecycleBin is used and if no object was found in the recycle bin" {

--- a/Tests/Unit/MSFT_xADServicePrincipalName.Tests.ps1
+++ b/Tests/Unit/MSFT_xADServicePrincipalName.Tests.ps1
@@ -204,7 +204,7 @@ try
 
                     $result = Set-TargetResource @testPresentParams
 
-                    Assert-MockCalled Set-ADObject -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Set-ADObject -Scope It -Times 1 -Exactly
                 }
             }
 
@@ -223,8 +223,8 @@ try
 
                     $result = Set-TargetResource @testPresentParams
 
-                    Assert-MockCalled Set-ADObject -Scope It -Times 1 -Exactly -ParameterFilter { $null -ne $Add }
-                    Assert-MockCalled Set-ADObject -Scope It -Times 1 -Exactly -ParameterFilter { $null -ne $Remove }
+                    Assert-MockCalled -CommandName Set-ADObject -Scope It -Times 1 -Exactly -ParameterFilter { $null -ne $Add }
+                    Assert-MockCalled -CommandName Set-ADObject -Scope It -Times 1 -Exactly -ParameterFilter { $null -ne $Remove }
                 }
             }
 
@@ -239,7 +239,7 @@ try
 
                     $result = Set-TargetResource @testAbsentParams
 
-                    Assert-MockCalled Set-ADObject -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Set-ADObject -Scope It -Times 1 -Exactly
                 }
             }
         }

--- a/Tests/Unit/MSFT_xADUser.Tests.ps1
+++ b/Tests/Unit/MSFT_xADUser.Tests.ps1
@@ -87,7 +87,7 @@ try
 
                 Get-TargetResource @testPresentParams -DomainController $testDomainController;
 
-                Assert-MockCalled Get-ADUser -ParameterFilter { $Server -eq $testDomainController } -Scope It
+                Assert-MockCalled -CommandName Get-ADUser -ParameterFilter { $Server -eq $testDomainController } -Scope It
             }
 
             It "Calls 'Get-ADUser' with 'Credential' parameter when 'DomainAdministratorCredential' specified" {
@@ -95,7 +95,7 @@ try
 
                 Get-TargetResource @testPresentParams -DomainAdministratorCredential $testCredential;
 
-                Assert-MockCalled Get-ADUser -ParameterFilter { $Credential -eq $testCredential } -Scope It
+                Assert-MockCalled -CommandName Get-ADUser -ParameterFilter { $Credential -eq $testCredential } -Scope It
             }
 
         }
@@ -148,7 +148,7 @@ try
 
                 Test-TargetResource @testPresentParams -Password $testCredential;
 
-                Assert-MockCalled Test-Password -ParameterFilter { $PasswordAuthentication -eq 'Default' } -Scope It
+                Assert-MockCalled -CommandName Test-Password -ParameterFilter { $PasswordAuthentication -eq 'Default' } -Scope It
             }
 
             It "Calls 'Test-Password' with 'Negotiate' PasswordAuthentication when specified" {
@@ -157,7 +157,7 @@ try
 
                 Test-TargetResource @testPresentParams -Password $testCredential -PasswordAuthentication 'Negotiate';
 
-                Assert-MockCalled Test-Password -ParameterFilter { $PasswordAuthentication -eq 'Negotiate' } -Scope It
+                Assert-MockCalled -CommandName Test-Password -ParameterFilter { $PasswordAuthentication -eq 'Negotiate' } -Scope It
             }
 
             foreach ($testParameter in $testStringProperties) {
@@ -294,7 +294,7 @@ try
 
                 Set-TargetResource @newPresentParams;
 
-                Assert-MockCalled New-ADUser -ParameterFilter { $Name -eq $newUserName } -Scope It
+                Assert-MockCalled -CommandName New-ADUser -ParameterFilter { $Name -eq $newUserName } -Scope It
             }
 
             It "Calls 'Move-ADObject' when 'Ensure' is 'Present', the account exists but Path is incorrect" {
@@ -309,7 +309,7 @@ try
 
                 Set-TargetResource @testPresentParams -Path $testTargetPath -Enabled $true;
 
-                Assert-MockCalled Move-ADObject -ParameterFilter { $TargetPath -eq $testTargetPath } -Scope It
+                Assert-MockCalled -CommandName Move-ADObject -ParameterFilter { $TargetPath -eq $testTargetPath } -Scope It
             }
 
             It "Calls 'Rename-ADObject' when 'Ensure' is 'Present', the account exists but 'CommonName' is incorrect" {
@@ -320,7 +320,7 @@ try
 
                 Set-TargetResource @testPresentParams -CommonName $testCommonName -Enabled $true;
 
-                Assert-MockCalled Rename-ADObject -ParameterFilter { $NewName -eq $testCommonName } -Scope It
+                Assert-MockCalled -CommandName Rename-ADObject -ParameterFilter { $NewName -eq $testCommonName } -Scope It
             }
 
             It "Calls 'Set-ADAccountPassword' when 'Password' parameter is specified" {
@@ -330,7 +330,7 @@ try
 
                 Set-TargetResource @testPresentParams -Password $testCredential;
 
-                Assert-MockCalled Set-ADAccountPassword -ParameterFilter { $NewPassword -eq $testCredential.Password } -Scope It
+                Assert-MockCalled -CommandName Set-ADAccountPassword -ParameterFilter { $NewPassword -eq $testCredential.Password } -Scope It
             }
 
             It "Calls 'Set-ADUser' with 'Replace' when existing matching AD property is null" {
@@ -344,7 +344,7 @@ try
 
                 Set-TargetResource @testPresentParams -Description 'My custom description';
 
-                Assert-MockCalled Set-ADUser -ParameterFilter { $Replace.ContainsKey($testADPropertyName) } -Scope It -Exactly 1;
+                Assert-MockCalled -CommandName Set-ADUser -ParameterFilter { $Replace.ContainsKey($testADPropertyName) } -Scope It -Exactly 1;
             }
 
             It "Calls 'Set-ADUser' with 'Replace' when existing matching AD property is empty" {
@@ -358,7 +358,7 @@ try
 
                 Set-TargetResource @testPresentParams -Description 'My custom description';
 
-                Assert-MockCalled Set-ADUser -ParameterFilter { $Replace.ContainsKey($testADPropertyName) } -Scope It -Exactly 1;
+                Assert-MockCalled -CommandName Set-ADUser -ParameterFilter { $Replace.ContainsKey($testADPropertyName) } -Scope It -Exactly 1;
             }
 
             It "Calls 'Set-ADUser' with 'Remove' when new matching AD property is empty" {
@@ -372,7 +372,7 @@ try
 
                 Set-TargetResource @testPresentParams -Description '';
 
-                Assert-MockCalled Set-ADUser -ParameterFilter { $Remove.ContainsKey($testADPropertyName) } -Scope It -Exactly 1;
+                Assert-MockCalled -CommandName Set-ADUser -ParameterFilter { $Remove.ContainsKey($testADPropertyName) } -Scope It -Exactly 1;
             }
 
             It "Calls 'Set-ADUser' with 'Replace' when existing mismatched AD property is null" {
@@ -386,7 +386,7 @@ try
 
                 Set-TargetResource @testPresentParams -JobTitle 'Gaffer';
 
-                Assert-MockCalled Set-ADUser -ParameterFilter { $Replace.ContainsKey($testADPropertyName) } -Scope It -Exactly 1;
+                Assert-MockCalled -CommandName Set-ADUser -ParameterFilter { $Replace.ContainsKey($testADPropertyName) } -Scope It -Exactly 1;
             }
 
             It "Calls 'Set-ADUser' with 'Replace' when existing mismatched AD property is empty" {
@@ -400,7 +400,7 @@ try
 
                 Set-TargetResource @testPresentParams -JobTitle 'Gaffer';
 
-                Assert-MockCalled Set-ADUser -ParameterFilter { $Replace.ContainsKey($testADPropertyName) } -Scope It -Exactly 1;
+                Assert-MockCalled -CommandName Set-ADUser -ParameterFilter { $Replace.ContainsKey($testADPropertyName) } -Scope It -Exactly 1;
             }
 
             It "Calls 'Set-ADUser' with 'Remove' when new mismatched AD property is empty" {
@@ -414,7 +414,7 @@ try
 
                 Set-TargetResource @testPresentParams -JobTitle '';
 
-                Assert-MockCalled Set-ADUser -ParameterFilter { $Remove.ContainsKey($testADPropertyName) } -Scope It -Exactly 1;
+                Assert-MockCalled -CommandName Set-ADUser -ParameterFilter { $Remove.ContainsKey($testADPropertyName) } -Scope It -Exactly 1;
             }
 
             It "Calls 'Remove-ADUser' when 'Ensure' is 'Absent' and user account exists" {
@@ -423,7 +423,7 @@ try
 
                 Set-TargetResource @testAbsentParams;
 
-                Assert-MockCalled Remove-ADUser -ParameterFilter { $Identity.ToString() -eq $testAbsentParams.UserName } -Scope It
+                Assert-MockCalled -CommandName Remove-ADUser -ParameterFilter { $Identity.ToString() -eq $testAbsentParams.UserName } -Scope It
             }
 
         }


### PR DESCRIPTION
Implemented restoring groups, users, computers and OUs from recycle bin. The resource will throw an error when the restoration cannot be completed due to the container not existing.
Using the new feature is opt-in and requires using the new parameter RestoreFromRecycleBin.

Fixes #211

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xactivedirectory/217)
<!-- Reviewable:end -->
