### PR TITLE
xADGroup: Implemented multidomain group members (fixes #152, close #174)

### DIFF
--- a/DSCResources/MSFT_xADCommon/MSFT_xADCommon.psm1
+++ b/DSCResources/MSFT_xADCommon/MSFT_xADCommon.psm1
@@ -10,6 +10,7 @@ data localizedString
         IncludeAndExcludeAreEmptyError = The '{0}' and '{1}' parameters are either both null or empty.  At least one member must be specified in one of these parameters.
         ModeConversionError            = Converted mode {0} is not a {1}.
         RecycleBinRestoreFailed        = Restoring {0} ({1}) from the recycle bin failed. Error message: {2}.
+        EmptyDomainError               = No domain name retrieved for group member {0} in group {1}.
 
         CheckingMembers                = Checking for '{0}' members.
         MembershipCountMismatch        = Membership count is not correct. Expected '{0}' members, actual '{1}' members.
@@ -22,6 +23,8 @@ data localizedString
         FindInRecycleBin               = Finding objects in the recycle bin matching the filter {0}.
         FoundRestoreTargetInRecycleBin = Found object {0} ({1}) in the recycle bin as {2}. Attempting to restore the object.
         RecycleBinRestoreSuccessful    = Successfully restored object {0} ({1}) from the recycle bin.
+        GroupMembershipMultipleDomains = Group membership objects are in '{0}' different AD Domains.
+        AddingGroupMember              = Adding member '{0}' from domain '{1}' to AD group '{2}'.
 '@
 }
 
@@ -55,7 +58,8 @@ function Assert-Module
 } #end function Assert-Module
 
 # Internal function to test whether computer is a member of a domain
-function Test-DomainMember {
+function Test-DomainMember
+{
     [CmdletBinding()]
     [OutputType([System.Boolean])]
     param ( )
@@ -65,7 +69,8 @@ function Test-DomainMember {
 
 
 # Internal function to get the domain name of the computer
-function Get-DomainName {
+function Get-DomainName
+{
     [CmdletBinding()]
     [OutputType([System.String])]
     param ( )
@@ -74,10 +79,11 @@ function Get-DomainName {
 } # function Get-DomainName
 
 # Internal function to build domain FQDN
-function Resolve-DomainFQDN {
+function Resolve-DomainFQDN
+{
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [OutputType([System.String])]
         [System.String] $DomainName,
 
@@ -99,7 +105,7 @@ function Test-ADDomain
     [OutputType([System.Boolean])]
     param
     (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [System.String] $DomainName,
 
         [Parameter()]
@@ -151,7 +157,7 @@ function Get-ADObjectParentDN
     [OutputType([System.String])]
     param
     (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [System.String]
         $DN
     )
@@ -169,18 +175,22 @@ function Assert-MemberParameters
     [CmdletBinding()]
     param
     (
+        [Parameter()]
         [ValidateNotNull()]
         [System.String[]]
         $Members,
 
+        [Parameter()]
         [ValidateNotNull()]
         [System.String[]]
         $MembersToInclude,
 
+        [Parameter()]
         [ValidateNotNull()]
         [System.String[]]
         $MembersToExclude,
 
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
         $ModuleName = 'xActiveDirectory'
@@ -244,7 +254,9 @@ function Remove-DuplicateMembers
     [OutputType([System.String[]])]
     param
     (
-        [System.String[]] $Members
+        [Parameter()]
+        [System.String[]]
+        $Members
     )
 
     Set-StrictMode -Version Latest
@@ -289,21 +301,25 @@ function Test-Members
     param
     (
         ## Existing array members
+        [Parameter()]
         [AllowNull()]
         [System.String[]]
         $ExistingMembers,
 
         ## Explicit array members
+        [Parameter()]
         [AllowNull()]
         [System.String[]]
         $Members,
 
         ## Compulsory array members
+        [Parameter()]
         [AllowNull()]
         [System.String[]]
         $MembersToInclude,
 
         ## Excluded array members
+        [Parameter()]
         [AllowNull()]
         [System.String[]]
         $MembersToExclude
@@ -380,12 +396,12 @@ function ConvertTo-TimeSpan
     [OutputType([System.TimeSpan])]
     param
     (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.UInt32]
         $TimeSpan,
 
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [ValidateSet('Seconds','Minutes','Hours','Days')]
         [System.String]
         $TimeSpanType
@@ -419,12 +435,12 @@ function ConvertFrom-TimeSpan
     [OutputType([System.Int32])]
     param
     (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.TimeSpan]
         $TimeSpan,
 
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [ValidateSet('Seconds','Minutes','Hours','Days')]
         [System.String]
         $TimeSpanType
@@ -466,7 +482,7 @@ function Get-ADCommonParameters
     [OutputType([System.Collections.Hashtable])]
     param
     (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [Alias('UserName','GroupName','ComputerName')]
         [System.String]
@@ -542,12 +558,12 @@ function ThrowInvalidOperationError
     [CmdletBinding()]
     param
     (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
         $ErrorId,
 
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
         $ErrorMessage
@@ -564,12 +580,12 @@ function ThrowInvalidArgumentError
     [CmdletBinding()]
     param
     (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
         $ErrorId,
 
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
         $ErrorMessage
@@ -589,10 +605,10 @@ function Test-ADReplicationSite
     [OutputType([System.Boolean])]
     param
     (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [System.String] $SiteName,
 
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [System.String] $DomainName,
 
         [Parameter()]
@@ -601,7 +617,7 @@ function Test-ADReplicationSite
     )
 
     Write-Verbose -Message ($localizedString.CheckingSite -f $SiteName);
-    
+
     $existingDC = "$((Get-ADDomainController -Discover -DomainName $DomainName -ForceDiscover).HostName)";
 
     try
@@ -635,6 +651,7 @@ function ConvertTo-DeploymentForestMode
             [System.Nullable``1[Microsoft.ActiveDirectory.Management.ADForestMode]]
         $Mode,
 
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
         $ModuleName = 'xActiveDirectory'
@@ -646,7 +663,7 @@ function ConvertTo-DeploymentForestMode
     {
         $convertedMode = $Mode -as [Microsoft.DirectoryServices.Deployment.Types.ForestMode]
     }
-    
+
     if ($PSCmdlet.ParameterSetName -eq 'ById')
     {
         $convertedMode = $ModeId -as [Microsoft.DirectoryServices.Deployment.Types.ForestMode]
@@ -679,18 +696,19 @@ function ConvertTo-DeploymentDomainMode
         [System.Nullable``1[Microsoft.ActiveDirectory.Management.ADDomainMode]]
         $Mode,
 
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
         $ModuleName = 'xActiveDirectory'
     )
-    
+
     $convertedMode = $null
 
     if ($PSCmdlet.ParameterSetName -eq 'ByName' -and $Mode)
     {
         $convertedMode = $Mode -as [Microsoft.DirectoryServices.Deployment.Types.DomainMode]
     }
-    
+
     if ($PSCmdlet.ParameterSetName -eq 'ById')
     {
         $convertedMode = $ModeId -as [Microsoft.DirectoryServices.Deployment.Types.DomainMode]
@@ -709,7 +727,7 @@ function Restore-ADCommonObject
     [CmdletBinding()]
     param
     (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [Alias('UserName','GroupName','ComputerName')]
         [System.String]
@@ -771,4 +789,101 @@ function Restore-ADCommonObject
     }
 
     return $restoredObject
+}
+
+<#
+.Synopsis
+    Author: Robert D. Biddle (https://github.com/RobBiddle)
+    Created: December.20.2017
+.DESCRIPTION
+    Takes an Active Directory DistinguishedName as input, returns the domain FQDN
+.EXAMPLE
+    Get-ADDomainNameFromDistinguishedName 'CN=ExampleObject,OU=ExampleOU,DC=example,DC=com'
+#>
+function Get-ADDomainNameFromDistinguishedName
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter()]
+        [System.String]
+        $DN
+    )
+
+    if ($DN -notlike '*DC=*') { return }
+
+    $SplitDN = ($DN -split 'DC=')
+    $DomainDNSplitParts = $SplitDN[1..$SplitDN.Length]
+    $DomainDN = ""
+    foreach ($part in $DomainDNSplitParts)
+    {
+        $DomainDN += "DC=$part"
+    }
+
+    $DomainName = (($DomainDN -replace 'DC=', '') -replace ',', '.')
+    return $DomainName
+
+} #end function Get-ADDomainNameFromDistinguishedName
+
+<#
+.SYNOPSIS
+    Add group member from current or different domain
+.NOTES
+    Author:
+      Original code: Robert D. Biddle (https://github.com/RobBiddle)
+      Refactored code: Jan-Hendrik Peters (https://github.com/nyanhp)
+#>
+function Add-ADCommonGroupMember
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter()]
+        [string[]]
+        $Members,
+
+        [Parameter()]
+        [hashtable]
+        $Parameters,
+
+        [Parameter()]
+        [switch]
+        $MembersInMultipleDomains
+    )
+
+    Assert-Module -ModuleName ActiveDirectory
+
+    if ($MembersInMultipleDomains.IsPresent)
+    {
+        foreach($member in $Members)
+        {
+            $memberDomain = Get-ADDomainNameFromDistinguishedName -DN $member
+
+            if (-not $memberDomain)
+            {
+                ThrowInvalidArgumentError -ErrorId "$($member)_EmptyDomainError" -ErrorMessage $localizedString.EmptyDomainError
+            }
+
+            Write-Verbose -Message ($localizedString.AddingGroupMember -f $member, $memberDomain, $Parameters.GroupName)
+            $memberObjectClass = (Get-ADObject -Identity $member -Server $memberDomain -Properties ObjectClass).ObjectClass
+            if ($memberObjectClass -eq 'computer')
+            {
+                $memberObject = Get-ADComputer -Identity $member -Server $memberDomain
+            }
+            elseif ($memberObjectClass -eq 'group')
+            {
+                $memberObject = Get-ADGroup -Identity $member -Server $memberDomain
+            }
+            elseif ($memberObjectClass -eq 'user')
+            {
+                $memberObject = Get-ADUser -Identity $member -Server $memberDomain
+            }
+
+            Add-ADGroupMember @Parameters -Members $memberObject
+        }
+    }
+    else
+    {
+        Add-ADGroupMember @Parameters -Members $Members
+    }
 }

--- a/DSCResources/MSFT_xADCommon/MSFT_xADCommon.psm1
+++ b/DSCResources/MSFT_xADCommon/MSFT_xADCommon.psm1
@@ -791,13 +791,15 @@ function Restore-ADCommonObject
 }
 
 <#
-.Synopsis
-    Author: Robert D. Biddle (https://github.com/RobBiddle)
-    Created: December.20.2017
-.DESCRIPTION
-    Takes an Active Directory DistinguishedName as input, returns the domain FQDN
-.EXAMPLE
-    Get-ADDomainNameFromDistinguishedName 'CN=ExampleObject,OU=ExampleOU,DC=example,DC=com'
+    .SYNOPSIS
+        Author: Robert D. Biddle (https://github.com/RobBiddle)
+        Created: December.20.2017
+
+    .DESCRIPTION
+        Takes an Active Directory DistinguishedName as input, returns the domain FQDN
+
+    .EXAMPLE
+        Get-ADDomainNameFromDistinguishedName -DistinguishedName 'CN=ExampleObject,OU=ExampleOU,DC=example,DC=com'
 #>
 function Get-ADDomainNameFromDistinguishedName
 {
@@ -806,31 +808,34 @@ function Get-ADDomainNameFromDistinguishedName
     (
         [Parameter()]
         [System.String]
-        $DN
+        $DistinguishedName
     )
 
-    if ($DN -notlike '*DC=*') { return }
-
-    $SplitDN = ($DN -split 'DC=')
-    $DomainDNSplitParts = $SplitDN[1..$SplitDN.Length]
-    $DomainDN = ""
-    foreach ($part in $DomainDNSplitParts)
+    if ($DistinguishedName -notlike '*DC=*')
     {
-        $DomainDN += "DC=$part"
+        return
     }
 
-    $DomainName = (($DomainDN -replace 'DC=', '') -replace ',', '.')
-    return $DomainName
+    $splitDistinguishedName = ($DistinguishedName -split 'DC=')
+    $splitDistinguishedNameParts = $splitDistinguishedName[1..$splitDistinguishedName.Length]
+    $domainFqdn = ""
+    foreach ($part in $splitDistinguishedNameParts)
+    {
+        $domainFqdn += "DC=$part"
+    }
+
+    $domainName = $domainFqdn -replace 'DC=', '' -replace ',', '.'
+    return $domainName
 
 } #end function Get-ADDomainNameFromDistinguishedName
 
 <#
-.SYNOPSIS
-    Add group member from current or different domain
-.NOTES
-    Author:
-      Original code: Robert D. Biddle (https://github.com/RobBiddle)
-      Refactored code: Jan-Hendrik Peters (https://github.com/nyanhp)
+    .SYNOPSIS
+        Add group member from current or different domain
+
+    .NOTES
+        Author original code: Robert D. Biddle (https://github.com/RobBiddle)
+        Author refactored code: Jan-Hendrik Peters (https://github.com/nyanhp)
 #>
 function Add-ADCommonGroupMember
 {
@@ -856,11 +861,11 @@ function Add-ADCommonGroupMember
     {
         foreach($member in $Members)
         {
-            $memberDomain = Get-ADDomainNameFromDistinguishedName -DN $member
+            $memberDomain = Get-ADDomainNameFromDistinguishedName -DistinguishedName $member
 
             if (-not $memberDomain)
             {
-                ThrowInvalidArgumentError -ErrorId "$($member)_EmptyDomainError" -ErrorMessage $localizedString.EmptyDomainError
+                ThrowInvalidArgumentError -ErrorId "$($member)_EmptyDomainError" -ErrorMessage ($localizedString.EmptyDomainError -f $member, $Parameters.GroupName)
             }
 
             Write-Verbose -Message ($localizedString.AddingGroupMember -f $member, $memberDomain, $Parameters.GroupName)

--- a/DSCResources/MSFT_xADCommon/MSFT_xADCommon.psm1
+++ b/DSCResources/MSFT_xADCommon/MSFT_xADCommon.psm1
@@ -23,7 +23,6 @@ data localizedString
         FindInRecycleBin               = Finding objects in the recycle bin matching the filter {0}.
         FoundRestoreTargetInRecycleBin = Found object {0} ({1}) in the recycle bin as {2}. Attempting to restore the object.
         RecycleBinRestoreSuccessful    = Successfully restored object {0} ({1}) from the recycle bin.
-        GroupMembershipMultipleDomains = Group membership objects are in '{0}' different AD Domains.
         AddingGroupMember              = Adding member '{0}' from domain '{1}' to AD group '{2}'.
 '@
 }

--- a/DSCResources/MSFT_xADGroup/MSFT_xADGroup.psm1
+++ b/DSCResources/MSFT_xADGroup/MSFT_xADGroup.psm1
@@ -23,6 +23,7 @@ data LocalizedData
         GroupNotFound                  = AD Group '{0}' was not found
         NotDesiredPropertyState        = AD Group '{0}' is not correct. Expected '{1}', actual '{2}'
         UpdatingGroupProperty          = Updating AD Group property '{0}' to '{1}'
+        GroupMembershipMultipleDomains = Group membership objects are in '{0}' different AD Domains.
 '@
 }
 
@@ -413,7 +414,7 @@ function Set-TargetResource
             $GroupMemberDomainCount = ($GroupMemberDomains | Select-Object -Unique).count
             if( ($GroupMemberDomainCount -gt 1) -or ($GroupMemberDomains -ine (Get-DomainName)).count -gt 0  )
             {
-                Write-Verbose ($LocalizedData.GroupMembershipMultipleDomains -f $GroupMemberDomainCount);
+                Write-Verbose -Message ($LocalizedData.GroupMembershipMultipleDomains -f $GroupMemberDomainCount);
                 $MembersInMultipleDomains = $true
             }
         }

--- a/DSCResources/MSFT_xADGroup/MSFT_xADGroup.psm1
+++ b/DSCResources/MSFT_xADGroup/MSFT_xADGroup.psm1
@@ -409,10 +409,10 @@ function Set-TargetResource
             $GroupMemberDomains = @();
             foreach($member in $AllMembers)
             {
-                $GroupMemberDomains += Get-ADDomainNameFromDistinguishedName -DN $member
+                $GroupMemberDomains += Get-ADDomainNameFromDistinguishedName -DistinguishedName $member
             }
             $GroupMemberDomainCount = ($GroupMemberDomains | Select-Object -Unique).count
-            if( ($GroupMemberDomainCount -gt 1) -or ($GroupMemberDomains -ine (Get-DomainName)).count -gt 0  )
+            if( $GroupMemberDomainCount -gt 1 -or ($GroupMemberDomains -ine (Get-DomainName)).Count -gt 0  )
             {
                 Write-Verbose -Message ($LocalizedData.GroupMembershipMultipleDomains -f $GroupMemberDomainCount);
                 $MembersInMultipleDomains = $true

--- a/DSCResources/MSFT_xADGroup/MSFT_xADGroup.psm1
+++ b/DSCResources/MSFT_xADGroup/MSFT_xADGroup.psm1
@@ -402,6 +402,22 @@ function Set-TargetResource
 
     try
     {
+        if ($MembershipAttribute -eq 'DistinguishedName')
+        {
+            $AllMembers = $Members + $MembersToInclude + $MembersToExclude
+            $GroupMemberDomains = @();
+            foreach($member in $AllMembers)
+            {
+                $GroupMemberDomains += Get-ADDomainNameFromDistinguishedName -DN $member
+            }
+            $GroupMemberDomainCount = ($GroupMemberDomains | Select-Object -Unique).count
+            if( ($GroupMemberDomainCount -gt 1) -or ($GroupMemberDomains -ine (Get-DomainName)).count -gt 0  )
+            {
+                Write-Verbose ($LocalizedData.GroupMembershipMultipleDomains -f $GroupMemberDomainCount);
+                $MembersInMultipleDomains = $true
+            }
+        }
+
         $adGroup = Get-ADGroup @adGroupParams -Property Name,GroupScope,GroupCategory,DistinguishedName,Description,DisplayName,ManagedBy,Info
 
         if ($Ensure -eq 'Present')
@@ -471,13 +487,13 @@ function Set-TargetResource
                         Remove-ADGroupMember @adGroupParams -Members $adGroupMembers -Confirm:$false
                     }
                     Write-Verbose -Message ($LocalizedData.AddingGroupMembers -f $Members.Count, $GroupName)
-                    Add-ADGroupMember @adGroupParams -Members $Members
+                    Add-ADCommonGroupMember -Parameter $adGroupParams -Members $Members -MembersInMultipleDomains:$MembersInMultipleDomains
                 }
                 if ($PSBoundParameters.ContainsKey('MembersToInclude') -and -not [system.string]::IsNullOrEmpty($MembersToInclude))
                 {
                     $MembersToInclude = Remove-DuplicateMembers -Members $MembersToInclude
                     Write-Verbose -Message ($LocalizedData.AddingGroupMembers -f $MembersToInclude.Count, $GroupName)
-                    Add-ADGroupMember @adGroupParams -Members $MembersToInclude
+                    Add-ADCommonGroupMember -Parameter $adGroupParams -Members $MembersToInclude -MembersInMultipleDomains:$MembersInMultipleDomains
                 }
                 if ($PSBoundParameters.ContainsKey('MembersToExclude') -and -not [system.string]::IsNullOrEmpty($MembersToExclude))
                 {
@@ -518,7 +534,7 @@ function Set-TargetResource
             {
                 $adGroupParams['Path'] = $Path
             }
-            
+
             <#
                 Create group
                 Try to restore account first if it exists
@@ -554,13 +570,13 @@ function Set-TargetResource
             {
                 $Members = Remove-DuplicateMembers -Members $Members
                 Write-Verbose -Message ($LocalizedData.AddingGroupMembers -f $Members.Count, $GroupName)
-                Add-ADGroupMember @adGroupParams -Members $Members
+                Add-ADCommonGroupMember -Parameter $adGroupParams -Members $Members -MembersInMultipleDomains:$MembersInMultipleDomains
             }
             elseif ($PSBoundParameters.ContainsKey('MembersToInclude') -and -not [system.string]::IsNullOrEmpty($MembersToInclude))
             {
                 $MembersToInclude = Remove-DuplicateMembers -Members $MembersToInclude
                 Write-Verbose -Message ($LocalizedData.AddingGroupMembers -f $MembersToInclude.Count, $GroupName)
-                Add-ADGroupMember @adGroupParams -Members $MembersToInclude
+                Add-ADCommonGroupMember -Parameter $adGroupParams -Members $MembersToInclude -MembersInMultipleDomains:$MembersInMultipleDomains
             }
 
         }

--- a/Examples/Resources/xADGroup/1-NewGroup.ps1
+++ b/Examples/Resources/xADGroup/1-NewGroup.ps1
@@ -1,0 +1,17 @@
+<#
+.EXAMPLE
+    This example creates a new domain-local group in contoso
+#>
+configuration Example
+{
+    Import-DscResource -ModuleName xActiveDirectory
+
+    node localhost
+    {
+        xADGroup dl1
+        {
+            GroupName = 'DL_APP_1'
+            GroupScope = 'DomainLocal'
+        }
+    }
+}

--- a/Examples/Resources/xADGroup/2-NewGroupWithMembers.ps1
+++ b/Examples/Resources/xADGroup/2-NewGroupWithMembers.ps1
@@ -1,0 +1,18 @@
+<#
+.EXAMPLE
+    This example creates a new domain-local group in contoso with three members.
+#>
+configuration Example
+{
+    Import-DscResource -ModuleName xActiveDirectory
+
+    node localhost
+    {
+        xADGroup dl1
+        {
+            GroupName = 'DL_APP_1'
+            GroupScope = 'DomainLocal'
+            Members = 'john','jim','sally'
+        }
+    }
+}

--- a/Examples/Resources/xADGroup/3-NewGroupMultidomainMembers.ps1
+++ b/Examples/Resources/xADGroup/3-NewGroupMultidomainMembers.ps1
@@ -1,0 +1,19 @@
+<#
+.EXAMPLE
+    This example creates a new domain-local group in contoso with three members in different domains.
+#>
+configuration Example
+{
+    Import-DscResource -ModuleName xActiveDirectory
+
+    node localhost
+    {
+        xADGroup dl1
+        {
+            GroupName = 'DL_APP_1'
+            GroupScope = 'DomainLocal'
+            MembershipAttribute = 'DistinguishedName'
+            Members = 'CN=john,OU=Accounts,DC=contoso,DC=com','CN=jim,OU=Accounts,DC=subdomain,DC=contoso,DC=com','CN=sally,OU=Accounts,DC=anothersub,DC=contoso,DC=com'
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -165,15 +165,18 @@ The xADGroup DSC resource will manage groups within Active Directory.
   * If not specified, no group membership changes are made.
   * If specified, all undefined group members will be removed the AD group.
   * This property cannot be specified with either 'MembersToInclude' or 'MembersToExclude'.
+  * To use other domain's members, specify the distinguished name of the object.
 * **`[String[]]` MembersToInclude** _(Write)_: Specifies AD objects that must be in the group.
   * If not specified, no group membership changes are made.
   * If specified, only the specified members are added to the group.
   * If specified, no users are removed from the group using this parameter.
+  * To use other domain's members, specify the distinguished name of the object.
   * This property cannot be specified with the 'Members' parameter.
 * **`[String[]]` MembersToExclude** _(Write)_: Specifies AD objects that _must not_ be in the group.
   * If not specified, no group membership changes are made.
   * If specified, only those specified are removed from the group.
   * If specified, no users are added to the group using this parameter.
+  * To use other domain's members, specify the distinguished name of the object.
   * This property cannot be specified with the 'Members' parameter.
 * **`[String]` MembershipAttribute** _(Write)_: Defines the AD object attribute that is used to determine group membership.
   * Valid values are 'SamAccountName', 'DistinguishedName', 'ObjectGUID' and 'SID'.

--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ The xADForestProperties DSC resource will manage User Principal Name (UPN) suffi
 
 * Added parameter to xADDomainController to support InstallationMediaPath ([issue #108](https://github.com/PowerShell/xActiveDirectory/issues/108)).
 * Updated xADDomainController schema to be standard and provide Descriptions.
+* Updated xADGroup to support group membership from multiple domains ([issue #152](https://github.com/PowerShell/xActiveDirectory/issues/152)). [Robert Biddle (@robbiddle)](https://github.com/RobBiddle) and [Jan-Hendrik Peters (@nyanhp)](https://github.com/nyanhp)
 
 ### 2.23.0.0
 

--- a/Tests/Unit/MSFT_xADCommon.Tests.ps1
+++ b/Tests/Unit/MSFT_xADCommon.Tests.ps1
@@ -569,7 +569,7 @@ try
             It 'Throws no exception when a null value is passed' {
                 { ConvertTo-DeploymentForestMode -Mode $null } | Should Not Throw
             }
-            
+
             It 'Throws no exception when an invalid mode id is selected' {
                 { ConvertTo-DeploymentForestMode -ModeId 666 } | Should Not Throw
             }
@@ -609,7 +609,7 @@ try
             It 'Throws no exception when a null value is passed' {
                 { ConvertTo-DeploymentDomainMode -Mode $null } | Should Not Throw
             }
-            
+
             It 'Throws no exception when an invalid mode id is selected' {
                 { ConvertTo-DeploymentDomainMode -ModeId 666 } | Should Not Throw
             }
@@ -639,7 +639,7 @@ try
                 ObjectClass       = 'user'
                 ObjectGUID        = 'd3c8b8c1-c42b-4533-af7d-3aa73ecd2216'
             }
-            
+
             function Restore-ADObject { }
 
             $getAdCommonParameterReturnValue = @{Identity = 'something'}
@@ -675,7 +675,7 @@ try
                     {Restore-ADCommonObject -Identity $restoreIdentity -ObjectClass $restoreObjectClass} | Should -Throw -ExceptionType ([System.InvalidOperationException])
                 }
             }
-            
+
             Context 'When there are no objects in the recycle bin' {
                 Mock -CommandName Get-ADObject
                 Mock -CommandName Get-ADCommonParameters -MockWith { return $getAdCommonParameterReturnValue}
@@ -683,11 +683,175 @@ try
 
                 It 'Should return $null' {
                     Restore-ADCommonObject -Identity $restoreIdentity -ObjectClass $restoreObjectClass | Should -Be $null
-                }                
+                }
 
                 It 'Should not call Restore-ADObject' {
                     Restore-ADCommonObject -Identity $restoreIdentity -ObjectClass $restoreObjectClass
                     Assert-MockCalled -CommandName Restore-ADObject -Exactly -Times 0 -Scope It
+                }
+            }
+        }
+        #endregion
+
+        #region Get-ADDomainNameFromDistinguishedName
+        Describe "$($Global:DSCResourceName)\Get-ADDomainNameFromDistinguishedName" {
+            $validDistinguishedNames = @(
+                @{
+                    DN     = 'CN=group1,OU=Group,OU=Wacken,DC=contoso,DC=com'
+                    Domain = 'contoso.com'
+                }
+                @{
+                    DN     = 'CN=group1,OU=Group,OU=Wacken,DC=sub,DC=contoso,DC=com'
+                    Domain = 'sub.contoso.com'
+                }
+                @{
+                    DN     = 'CN=group1,OU=Group,OU=Wacken,DC=child,DC=sub,DC=contoso,DC=com'
+                    Domain = 'child.sub.contoso.com'
+                }
+            )
+            $invalidDistinguishedNames = @(
+                'Group1'
+                'contoso\group1'
+                'user1@contoso.com'
+            )
+
+            Context 'The distinguished name is valid' {
+                foreach ($name in $validDistinguishedNames)
+                {
+                    It "Should match domain $($name.Domain)" {
+                        Get-ADDomainNameFromDistinguishedName -DN $name.Dn | Should -Be $name.Domain
+                    }
+                }
+            }
+
+            Context 'The distinguished name is invalid' {
+                foreach ($name in $invalidDistinguishedNames)
+                {
+                    It "Should return `$null for $name" {
+                        Get-ADDomainNameFromDistinguishedName -DN $name | Should -Be $null
+                    }
+                }
+            }
+        }
+        #endregion
+
+        #region Add-AdCommonGroupMember
+        Describe "$($Global:DSCResourceName)\Add-ADCommonGroupMember" {
+            Mock -CommandName Assert-Module -ParameterFilter { $ModuleName -eq 'ActiveDirectory' }
+
+            $memberData = @(
+                [pscustomobject]@{
+                    Name = 'CN=Account1,DC=contoso,DC=com'
+                    Domain = 'contoso.com'
+                }
+                [pscustomobject]@{
+                    Name = 'CN=Group1,DC=contoso,DC=com'
+                    Domain = 'contoso.com'
+                }
+                [pscustomobject]@{
+                    Name = 'CN=Computer1,DC=contoso,DC=com'
+                    Domain = 'contoso.com'
+                }
+                [pscustomobject]@{
+                    Name = 'CN=Account1,DC=a,DC=contoso,DC=com'
+                    Domain = 'a.contoso.com'
+                }
+                [pscustomobject]@{
+                    Name = 'CN=Group1,DC=a,DC=contoso,DC=com'
+                    Domain = 'a.contoso.com'
+                }
+                [pscustomobject]@{
+                    Name = 'CN=Computer1,DC=a,DC=contoso,DC=com'
+                    Domain = 'a.contoso.com'
+                }
+                [pscustomobject]@{
+                    Name = 'CN=Account1,DC=b,DC=contoso,DC=com'
+                    Domain = 'b.contoso.com'
+                }
+                [pscustomobject]@{
+                    Name = 'CN=Group1,DC=b,DC=contoso,DC=com'
+                    Domain = 'b.contoso.com'
+                }
+                [pscustomobject]@{
+                    Name = 'CN=Computer1,DC=b,DC=contoso,DC=com'
+                    Domain = 'b.contoso.com'
+                }
+            )
+
+            $invalidMemberData = @(
+                'contoso.com\group1'
+                'user1@contoso.com'
+                'computer1.contoso.com'
+            )
+
+            $fakeParameters = @{
+                Identity = 'SomeGroup'
+            }
+
+            Context 'When all members are in the same domain' {
+                Mock -CommandName Add-ADGroupMember
+                $groupCount = 0
+                foreach ($domainGroup in ($memberData | Group-Object -Property Domain))
+                {
+                    $groupCount ++
+                    It "Should not throw an error when calling Add-ADCommonGroupMember" {
+                        Add-ADCommonGroupMember -Members $domainGroup.Group.Name -Parameters $fakeParameters
+                    }
+                }
+
+                It "Should have called Add-ADGroupMember $groupCount times" {
+                    Assert-MockCalled -CommandName Add-ADGroupMember -Exactly -Times $groupCount
+                }
+            }
+
+            Context 'When members are in different domains' {
+                Mock -CommandName Add-ADGroupMember
+                Mock -CommandName Get-ADObject -MockWith {
+                    param (
+                        [Parameter()]
+                        [string]
+                        $Identity,
+
+                        [Parameter()]
+                        [string]
+                        $Server,
+
+                        [Parameter()]
+                        [string[]]
+                        $Properties
+                    )
+
+                    $objectClass = switch ($Identity)
+                    {
+                        {$Identity -match 'Group'} { 'group' }
+                        {$Identity -match 'Account'} { 'user' }
+                        {$Identity -match 'Computer'} { 'computer' }
+                    }
+
+                    return ([PSCustomObject]@{
+                            objectClass = $objectClass
+                        })
+                }
+                # Mocks should return something that is used with Add-ADGroupMember
+                Mock -CommandName Get-ADComputer -MockWith { return 'placeholder' }
+                Mock -CommandName Get-ADGroup -MockWith { return 'placeholder' }
+                Mock -CommandName Get-ADUser -MockWith { return 'placeholder' }
+
+                It 'Should not throw an error' {
+                    {Add-ADCommonGroupMember -Members $memberData.Name -Parameters $fakeParameters -MembersInMultipleDomains} | Should -Not -Throw
+                }
+
+                It 'Should have called all mocked cmdlets' {
+                    Assert-MockCalled -CommandName Get-ADComputer -Exactly -Times $memberData.Where( {$_.Name -like '*Computer*'}).Count
+                    Assert-MockCalled -CommandName Get-ADUser -Exactly -Times $memberData.Where( {$_.Name -like '*Account*'}).Count
+                    Assert-MockCalled -CommandName Get-ADGroup -Exactly -Times $memberData.Where( {$_.Name -like '*Group*'}).Count
+                    Assert-MockCalled -CommandName Add-ADGroupMember -Exactly -Times $memberData.Count
+                }
+            }
+
+            Context 'When the domain name cannot be determined' {
+                It 'Should throw an InvalidArgumentException' {
+                    {Add-ADCommonGroupMember -Members $invalidMemberData  -Parameters $fakeParameters -MembersInMultipleDomains} | Should -Throw -ExceptionType ([System.ArgumentException])
                 }
             }
         }

--- a/Tests/Unit/MSFT_xADCommon.Tests.ps1
+++ b/Tests/Unit/MSFT_xADCommon.Tests.ps1
@@ -719,7 +719,7 @@ try
                 foreach ($name in $validDistinguishedNames)
                 {
                     It "Should match domain $($name.Domain)" {
-                        Get-ADDomainNameFromDistinguishedName -DN $name.Dn | Should -Be $name.Domain
+                        Get-ADDomainNameFromDistinguishedName -DistinguishedName $name.Dn | Should -Be $name.Domain
                     }
                 }
             }
@@ -728,7 +728,7 @@ try
                 foreach ($name in $invalidDistinguishedNames)
                 {
                     It "Should return `$null for $name" {
-                        Get-ADDomainNameFromDistinguishedName -DN $name | Should -Be $null
+                        Get-ADDomainNameFromDistinguishedName -DistinguishedName $name | Should -Be $null
                     }
                 }
             }
@@ -794,7 +794,7 @@ try
                 foreach ($domainGroup in ($memberData | Group-Object -Property Domain))
                 {
                     $groupCount ++
-                    It "Should not throw an error when calling Add-ADCommonGroupMember" {
+                    It 'Should not throw an error when calling Add-ADCommonGroupMember' {
                         Add-ADCommonGroupMember -Members $domainGroup.Group.Name -Parameters $fakeParameters
                     }
                 }

--- a/Tests/Unit/MSFT_xADGroup.Tests.ps1
+++ b/Tests/Unit/MSFT_xADGroup.Tests.ps1
@@ -23,7 +23,6 @@ $TestEnvironment = Initialize-TestEnvironment `
 # Begin Testing
 try
 {
-
     #region Pester Tests
 
     # The InModuleScope command allows you to perform white-box unit testing on the internal
@@ -398,23 +397,23 @@ try
             It "Adds group members when 'Ensure' is 'Present', the group exists and 'Members' are specified" {
                 Mock -CommandName Get-ADGroup -MockWith { throw New-Object Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException }
                 Mock -CommandName Set-ADGroup
-                Mock -CommandName Add-ADGroupMember
+                Mock -CommandName Add-ADCommonGroupMember
                 Mock -CommandName New-ADGroup -MockWith { return [PSCustomObject] $fakeADGroup; }
 
                 Set-TargetResource @testPresentParams -Members @($fakeADUser1.SamAccountName, $fakeADUser2.SamAccountName);
 
-                Assert-MockCalled -CommandName Add-ADGroupMember -Scope It
+                Assert-MockCalled -CommandName Add-ADCommonGroupMember -Scope It
             }
 
             It "Adds group members when 'Ensure' is 'Present', the group exists and 'MembersToInclude' are specified" {
                 Mock -CommandName Get-ADGroup -MockWith { throw New-Object Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException }
                 Mock -CommandName Set-ADGroup
-                Mock -CommandName Add-ADGroupMember
+                Mock -CommandName Add-ADCommonGroupMember
                 Mock -CommandName New-ADGroup -MockWith { return [PSCustomObject] $fakeADGroup; }
 
                 Set-TargetResource @testPresentParams -MembersToInclude @($fakeADUser1.SamAccountName, $fakeADUser2.SamAccountName);
 
-                Assert-MockCalled -CommandName Add-ADGroupMember -Scope It
+                Assert-MockCalled -CommandName Add-ADCommonGroupMember -Scope It
             }
 
             It "Moves group when 'Ensure' is 'Present', the group exists but the 'Path' has changed" {
@@ -436,13 +435,13 @@ try
                 Mock -CommandName Get-ADGroup -MockWith { return [PSCustomObject] $fakeADGroup; }
                 Mock -CommandName Set-ADGroup
                 Mock -CommandName Get-ADGroupMember -MockWith { return @($fakeADUser1, $fakeADUser2); }
-                Mock -CommandName Add-ADGroupMember
+                Mock -CommandName Add-ADCommonGroupMember
                 Mock -CommandName Remove-ADGroupMember
 
                 Set-TargetResource @testPresentParams -Members $fakeADuser1.SamAccountName;
 
                 Assert-MockCalled -CommandName Remove-ADGroupMember -Scope It -Exactly 1;
-                Assert-MockCalled -CommandName Add-ADGroupMember -Scope It -Exactly 1;
+                Assert-MockCalled -CommandName Add-ADCommonGroupMember -Scope It -Exactly 1;
             }
 
             It "Does not reset group membership when 'Ensure' is 'Present' and existing group is empty" {
@@ -471,11 +470,11 @@ try
                 Mock -CommandName Get-ADGroup -MockWith { return [PSCustomObject] $fakeADGroup; }
                 Mock -CommandName Set-ADGroup
                 Mock -CommandName Get-ADGroupMember -MockWith { return @($fakeADUser1, $fakeADUser2); }
-                Mock -CommandName Add-ADGroupMember
+                Mock -CommandName Add-ADCommonGroupMember
 
                 Set-TargetResource @testPresentParams -MembersToInclude $fakeADuser3.SamAccountName;
 
-                Assert-MockCalled -CommandName Add-ADGroupMember -Scope It -Exactly 1;
+                Assert-MockCalled -CommandName Add-ADCommonGroupMember -Scope It -Exactly 1;
             }
 
             It "Removes group when 'Ensure' is 'Absent' and group exists" {
@@ -500,7 +499,7 @@ try
 
             It "Calls 'Set-ADGroup' with credentials when 'Ensure' is 'Present' and the group does not exist  (#106)" {
                 Mock -CommandName Get-ADGroup -MockWith { throw New-Object Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException }
-                Mock -CommandName Set-ADGroup -ParameterFilter { $Credential -eq $testCredentials } 
+                Mock -CommandName Set-ADGroup -ParameterFilter { $Credential -eq $testCredentials }
                 Mock -CommandName New-ADGroup -MockWith { return [PSCustomObject] $fakeADGroup; }
 
                 Set-TargetResource @testPresentParams -Credential $testCredentials;
@@ -533,7 +532,7 @@ try
 
                 Mock -CommandName Get-ADGroup -MockWith { return [PSCustomObject] $fakeADUniversalGroup }
                 Mock -CommandName Set-ADGroup -ParameterFilter { $Identity -eq $fakeADUniversalGroup.Identity -and -not $PSBoundParameters.ContainsKey('GroupScope') }
-                Mock -CommandName Add-ADGroupMember
+                Mock -CommandName Add-ADCommonGroupMember
 
                 Set-TargetResource -GroupName $testUniversalPresentParams.GroupName -Members @($fakeADUser1.SamAccountName, $fakeADUser2.SamAccountName)
 
@@ -549,7 +548,7 @@ try
 
                 Mock -CommandName Get-ADGroup -MockWith { return [PSCustomObject] $fakeADUniversalGroup }
                 Mock -CommandName Set-ADGroup -ParameterFilter { $Identity -eq $fakeADUniversalGroup.Identity -and -not $PSBoundParameters.ContainsKey('GroupCategory') }
-                Mock -CommandName Add-ADGroupMember
+                Mock -CommandName Add-ADCommonGroupMember
 
                 Set-TargetResource -GroupName $testUniversalPresentParams.GroupName -Members @($fakeADUser1.SamAccountName, $fakeADUser2.SamAccountName)
 
@@ -565,7 +564,7 @@ try
 
                 Mock -CommandName Get-ADGroup -MockWith { return [PSCustomObject] $fakeADUniversalGroup }
                 Mock -CommandName Set-ADGroup -ParameterFilter { $Identity -eq $fakeADUniversalGroup.Identity -and -not $PSBoundParameters.ContainsKey('GroupScope') }
-                Mock -CommandName Add-ADGroupMember
+                Mock -CommandName Add-ADCommonGroupMember
 
                 $universalGroupInCompliance = Test-TargetResource -GroupName $testUniversalPresentParams.GroupName -DisplayName $testUniversalPresentParams.DisplayName
                 $universalGroupInCompliance | Should Be $true
@@ -580,7 +579,7 @@ try
 
                 Mock -CommandName Get-ADGroup -MockWith { return [PSCustomObject] $fakeADUniversalGroup }
                 Mock -CommandName Set-ADGroup -ParameterFilter { $Identity -eq $fakeADUniversalGroup.Identity -and -not $PSBoundParameters.ContainsKey('GroupScope') }
-                Mock -CommandName Add-ADGroupMember
+                Mock -CommandName Add-ADCommonGroupMember
 
                 $universalGroupInCompliance = Test-TargetResource -GroupName $testUniversalPresentParams.GroupName -DisplayName $testUniversalPresentParams.DisplayName
                 $universalGroupInCompliance | Should Be $true

--- a/Tests/Unit/MSFT_xADGroup.Tests.ps1
+++ b/Tests/Unit/MSFT_xADGroup.Tests.ps1
@@ -439,10 +439,10 @@ try
                     param (
                         [Parameter()]
                         [string]
-                        $DN
+                        $DistinguishedName
                     )
 
-                    if ($DN -match 'DC=sub')
+                    if ($DistinguishedName -match 'DC=sub')
                     {
                         return 'sub.contoso.com'
                     }


### PR DESCRIPTION
<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please prefix the PR title with the resource name,
    e.g. 'ResourceName: My short description'.
    If this is a breaking change, then also prefix the PR title
    with 'BREAKING CHANGE:',
    e.g. 'BREAKING CHANGE: ResourceName: My short description'.

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
-->
#### Pull Request (PR) description
This PR builds on the work done in #174 by @robbiddle and implements multi-domain group members.

This PR closes #174, which has been marked as abandoned.

#### This Pull Request (PR) fixes the following issues
- Fixes #152

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry under the Unreleased section of the change log in the README.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [x] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xactivedirectory/240)
<!-- Reviewable:end -->
