### PR TITLE
xADUser: Add TrustedForDelegation parameter to support Kerberos delegation

### DIFF
--- a/DSCResources/MSFT_xADUser/MSFT_xADUser.psm1
+++ b/DSCResources/MSFT_xADUser/MSFT_xADUser.psm1
@@ -77,6 +77,7 @@ $adPropertyMap = @(
     @{ Parameter = 'Manager'; }
     @{ Parameter = 'PasswordNeverExpires'; UseCmdletParameter = $true; }
     @{ Parameter = 'CannotChangePassword'; UseCmdletParameter = $true; }
+    @{ Parameter = 'TrustedForDelegation'; UseCmdletParameter = $true; }
 )
 
 function Get-TargetResource
@@ -335,6 +336,12 @@ function Get-TargetResource
         [ValidateNotNull()]
         [System.Boolean]
         $PasswordNeverExpires,
+
+        # Specifies whether an account is trusted for Kerberos delegation
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.Boolean]
+        $TrustedForDelegation,
 
         # Specifies the Active Directory Domain Services instance to use to perform the task.
         [Parameter()]
@@ -696,6 +703,12 @@ function Test-TargetResource
         [System.Boolean]
         $PasswordNeverExpires,
 
+        # Specifies whether an account is trusted for Kerberos delegation
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.Boolean]
+        $TrustedForDelegation,
+
         # Specifies the Active Directory Domain Services instance to use to perform the task.
         [Parameter()]
         [ValidateNotNull()]
@@ -1042,6 +1055,12 @@ function Set-TargetResource
         [ValidateNotNull()]
         [System.Boolean]
         $PasswordNeverExpires,
+
+        # Specifies whether an account is trusted for Kerberos delegation
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.Boolean]
+        $TrustedForDelegation,
 
         # Specifies the Active Directory Domain Services instance to use to perform the task.
         [Parameter()]

--- a/DSCResources/MSFT_xADUser/MSFT_xADUser.schema.mof
+++ b/DSCResources/MSFT_xADUser/MSFT_xADUser.schema.mof
@@ -47,6 +47,7 @@ class MSFT_xADUser : OMI_BaseResource
     [Write, Description("Specifies the user account credentials to use to perform this task"), EmbeddedInstance("MSFT_Credential")] String DomainAdministratorCredential;
     [Write, Description("Specifies the authentication context type used when testing passwords"), ValueMap{"Default","Negotiate"},Values{"Default","Negotiate"}] String PasswordAuthentication;
     [Write, Description("Specifies whether existing user's password should be reset (default $false)")] Boolean PasswordNeverResets;
+    [Write, Description("Specifies whether an account is trusted for Kerberos delegation (default $false)")] Boolean TrustedForDelegation;
     [Write, Description("Indicates whether or not the user object should first tried to be restored from the recycle bin before creating a new user object.")] Boolean RestoreFromRecycleBin;
     [Read, Description("Returns the X.500 path of the object")] String DistinguishedName;
 };

--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ The xADServicePrincipalName DSC resource will manage service principal names.
 * **`[String]` PasswordAuthentication** _(Write)_: Specifies the authentication context used when testing users' passwords.
   * The 'Negotiate' option supports NTLM authentication - which may be required when testing users' passwords when Active Directory Certificate Services (ADCS) is deployed.
 * **`[Boolean]` PasswordNeverResets** _(Write)_: Specifies whether existing user's password should be reset (default $false).
+* **`[Boolean]` TrustedForDelegation** _(Write)_: Specifies whether an account is trusted for Kerberos delegation (default $false).
 * **`[Boolean]` RestoreFromRecycleBin** _(Write)_: Indicates whether or not the user object should first tried to be restored from the recycle bin before creating a new user object.
 * **`[String]` DistinguishedName** _(Read)_: The user distinguished name, returned with Get.
 
@@ -378,6 +379,7 @@ The xADForestProperties DSC resource will manage User Principal Name (UPN) suffi
 * Added parameter to xADDomainController to support InstallationMediaPath ([issue #108](https://github.com/PowerShell/xActiveDirectory/issues/108)).
 * Updated xADDomainController schema to be standard and provide Descriptions.
 * Updated xADGroup to support group membership from multiple domains ([issue #152](https://github.com/PowerShell/xActiveDirectory/issues/152)). [Robert Biddle (@robbiddle)](https://github.com/RobBiddle) and [Jan-Hendrik Peters (@nyanhp)](https://github.com/nyanhp)
+* Added TrustedForDelegation parameter to xADUser to support enabling/disabling Kerberos delegation
 
 ### 2.23.0.0
 

--- a/README.md
+++ b/README.md
@@ -372,6 +372,7 @@ The xADForestProperties DSC resource will manage User Principal Name (UPN) suffi
 * Changes to xADComputer
   * Minor clean up of unit tests.
 * Changes to xADUser
+  * Added TrustedForDelegation parameter to xADUser to support enabling/disabling Kerberos delegation
   * Minor clean up of unit tests.
 
 ### 2.24.0.0
@@ -379,7 +380,6 @@ The xADForestProperties DSC resource will manage User Principal Name (UPN) suffi
 * Added parameter to xADDomainController to support InstallationMediaPath ([issue #108](https://github.com/PowerShell/xActiveDirectory/issues/108)).
 * Updated xADDomainController schema to be standard and provide Descriptions.
 * Updated xADGroup to support group membership from multiple domains ([issue #152](https://github.com/PowerShell/xActiveDirectory/issues/152)). [Robert Biddle (@robbiddle)](https://github.com/RobBiddle) and [Jan-Hendrik Peters (@nyanhp)](https://github.com/nyanhp)
-* Added TrustedForDelegation parameter to xADUser to support enabling/disabling Kerberos delegation
 
 ### 2.23.0.0
 

--- a/Tests/Unit/MSFT_xADUser.Tests.ps1
+++ b/Tests/Unit/MSFT_xADUser.Tests.ps1
@@ -46,12 +46,12 @@ try
         $testCredential = [System.Management.Automation.PSCredential]::Empty
 
         $testStringProperties = @(
-            'UserPrincipalName', 'DisplayName', 'Path',  'GivenName', 'Initials', 'Surname', 'Description', 'StreetAddress',
+            'UserPrincipalName', 'DisplayName', 'Path', 'GivenName', 'Initials', 'Surname', 'Description', 'StreetAddress',
             'POBox', 'City', 'State', 'PostalCode', 'Country', 'Department', 'Division', 'Company', 'Office', 'JobTitle',
             'EmailAddress', 'EmployeeID', 'EmployeeNumber', 'HomeDirectory', 'HomeDrive', 'HomePage', 'ProfilePath',
             'LogonScript', 'Notes', 'OfficePhone', 'MobilePhone', 'Fax', 'Pager', 'IPPhone', 'HomePhone','CommonName'
         )
-        $testBooleanProperties = @('PasswordNeverExpires', 'CannotChangePassword','Enabled')
+        $testBooleanProperties = @('PasswordNeverExpires', 'CannotChangePassword', 'TrustedForDelegation', 'Enabled');
 
         #region Function Get-TargetResource
         Describe "$($Global:DSCResourceName)\Get-TargetResource" {
@@ -517,6 +517,10 @@ try
 
             It "Throws when account is disabled and 'Password' is specified" {
                 { Assert-Parameters -Password $testCredential -Enabled $false } | Should Throw
+            }
+
+            It "Does not throw when 'TrustedForDelegation' is specified" {
+                { Assert-Parameters -TrustedForDelegation $true } | Should Not Throw
             }
         }
         #endregion


### PR DESCRIPTION
#### Pull Request (PR) description
Added new parameter to allow Kerberos delegation to be set on an Active Directory user.

#### This Pull Request (PR) fixes the following issues
None

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the README.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [x] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xactivedirectory/241)
<!-- Reviewable:end -->
