### PR TITLE
xActiveDirectory: Restoring an object no longer fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,26 @@
   - Updated unit tests to latest unit test template and refactored the
     tests for the function 'Set-TargetResource'.
   - Improved test code coverage.
+- Changes to xADComputer
+  - Restoring a computer account from the recycle bin no longer fails if
+    there are more than one object with the same name in the recycle bin.
+    Now it uses the object that was changed last using the property
+    `whenChanged` ([issue #271](https://github.com/PowerShell/xActiveDirectory/issues/271)).
+- Changes to xADGroup
+  - Restoring a group from the recycle bin no longer fails if there are
+    more than one object with the same name in the recycle bin. Now it
+    uses the object that was changed last using the property `whenChanged`
+    ([issue #271](https://github.com/PowerShell/xActiveDirectory/issues/271)).
+- Changes to xADOrganizationalUnit
+  - Restoring a organization unit from the recycle bin no longer fails if
+    there are more than one object with the same name in the recycle bin.
+    Now it uses the object that was changed last using the property `whenChanged`
+    ([issue #271](https://github.com/PowerShell/xActiveDirectory/issues/271)).
+- Changes to xADUser
+  - Restoring a user from the recycle bin no longer fails if there are
+    more than one object with the same name in the recycle bin. Now it
+    uses the object that was changed last using the property `whenChanged`
+    ([issue #271](https://github.com/PowerShell/xActiveDirectory/issues/271)).
 
 ## 2.25.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,21 +33,21 @@
   - Improved test code coverage.
 - Changes to xADComputer
   - Restoring a computer account from the recycle bin no longer fails if
-    there are more than one object with the same name in the recycle bin.
+    there is more than one object with the same name in the recycle bin.
     Now it uses the object that was changed last using the property
     `whenChanged` ([issue #271](https://github.com/PowerShell/xActiveDirectory/issues/271)).
 - Changes to xADGroup
-  - Restoring a group from the recycle bin no longer fails if there are
+  - Restoring a group from the recycle bin no longer fails if there is
     more than one object with the same name in the recycle bin. Now it
     uses the object that was changed last using the property `whenChanged`
     ([issue #271](https://github.com/PowerShell/xActiveDirectory/issues/271)).
 - Changes to xADOrganizationalUnit
-  - Restoring a organization unit from the recycle bin no longer fails if
-    there are more than one object with the same name in the recycle bin.
+  - Restoring an organizational unit from the recycle bin no longer fails
+    if there is more than one object with the same name in the recycle bin.
     Now it uses the object that was changed last using the property `whenChanged`
     ([issue #271](https://github.com/PowerShell/xActiveDirectory/issues/271)).
 - Changes to xADUser
-  - Restoring a user from the recycle bin no longer fails if there are
+  - Restoring a user from the recycle bin no longer fails if there is
     more than one object with the same name in the recycle bin. Now it
     uses the object that was changed last using the property `whenChanged`
     ([issue #271](https://github.com/PowerShell/xActiveDirectory/issues/271)).

--- a/Tests/Unit/MSFT_xADCommon.Tests.ps1
+++ b/Tests/Unit/MSFT_xADCommon.Tests.ps1
@@ -628,13 +628,26 @@ try
 
         #region Function Restore-ADCommonObject
         Describe "$($Global:DSCResourceName)\Restore-ADCommonObject" {
-            $getAdObjectReturnValue = [PSCustomObject]@{
-                Deleted           = $True
-                DistinguishedName = 'CN=a375347\0ADEL:d3c8b8c1-c42b-4533-af7d-3aa73ecd2216,CN=Deleted Objects,DC=contoso,DC=com'
-                Name              = 'a375347'
-                ObjectClass       = 'user'
-                ObjectGUID        = 'd3c8b8c1-c42b-4533-af7d-3aa73ecd2216'
-            }
+            $getAdObjectReturnValue = @(
+                [PSCustomObject] @{
+                    Deleted           = $true
+                    DistinguishedName = 'CN=a375347\0ADEL:f0e3f4fe-212b-43e7-83dd-c8f3b47ebb9c,CN=Deleted Objects,DC=contoso,DC=com'
+                    Name              = 'a375347'
+                    ObjectClass       = 'user'
+                    ObjectGUID        = 'f0e3f4fe-212b-43e7-83dd-c8f3b47ebb9c'
+                    # Make this one day older.
+                    whenChanged       = (Get-Date).AddDays(-1)
+                },
+                [PSCustomObject] @{
+                    Deleted           = $true
+                    DistinguishedName = 'CN=a375347\0ADEL:d3c8b8c1-c42b-4533-af7d-3aa73ecd2216,CN=Deleted Objects,DC=contoso,DC=com'
+                    Name              = 'a375347'
+                    ObjectClass       = 'user'
+                    ObjectGUID        = 'd3c8b8c1-c42b-4533-af7d-3aa73ecd2216'
+                    whenChanged       = Get-Date
+                }
+            )
+
             $restoreAdObjectReturnValue = [PSCustomObject]@{
                 DistinguishedName = 'CN=a375347,CN=Accounts,DC=contoso,DC=com'
                 Name              = 'a375347'
@@ -642,7 +655,9 @@ try
                 ObjectGUID        = 'd3c8b8c1-c42b-4533-af7d-3aa73ecd2216'
             }
 
-            function Restore-ADObject { }
+            function Restore-ADObject
+            {
+            }
 
             $getAdCommonParameterReturnValue = @{Identity = 'something'}
             $restoreIdentity = 'SomeObjectName'
@@ -650,8 +665,8 @@ try
             $restoreObjectWrongClass = 'wrong'
 
             Context 'When there are objects in the recycle bin' {
-                Mock -CommandName Get-ADObject -MockWith { return $getAdObjectReturnValue} -Verifiable
-                Mock -CommandName Get-ADCommonParameters -MockWith { return $getAdCommonParameterReturnValue}
+                Mock -CommandName Get-ADObject -MockWith { return $getAdObjectReturnValue } -Verifiable
+                Mock -CommandName Get-ADCommonParameters -MockWith { return $getAdCommonParameterReturnValue }
                 Mock -CommandName Restore-ADObject -Verifiable
 
                 It 'Should not throw when called with the correct parameters' {


### PR DESCRIPTION
#### Pull Request (PR) description
- Changes to xADComputer
  - Restoring a computer account from the recycle bin no longer fails if
    there are more than one object with the same name in the recycle bin.
    Now it uses the object that was changed last using the property
    `whenChanged` ([issue #271](https://github.com/PowerShell/xActiveDirectory/issues/271)).
- Changes to xADGroup
  - Restoring a group from the recycle bin no longer fails if there are
    more than one object with the same name in the recycle bin. Now it
    uses the object that was changed last using the property `whenChanged`
    ([issue #271](https://github.com/PowerShell/xActiveDirectory/issues/271)).
- Changes to xADOrganizationalUnit
  - Restoring a organization unit from the recycle bin no longer fails if
    there are more than one object with the same name in the recycle bin.
    Now it uses the object that was changed last using the property
    `whenChanged` ([issue #271](https://github.com/PowerShell/xActiveDirectory/issues/271)).
- Changes to xADUser
  - Restoring a user from the recycle bin no longer fails if there are
    more than one object with the same name in the recycle bin. Now it
    uses the object that was changed last using the property `whenChanged`
    ([issue #271](https://github.com/PowerShell/xActiveDirectory/issues/271)).

#### This Pull Request (PR) fixes the following issues
- Fixes #271 

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry under the Unreleased section in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xactivedirectory/272)
<!-- Reviewable:end -->
