### PR TITLE
xActiveDirectory: Suppressing Script Analyzer rule PSAvoidGlobalVars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 ## Unreleased
 
-- Changes to xADUser
-  - Added ServicePrincipalNames Property
-
 - Changes to xActiveDirectory
   - Added new helper functions in xADCommon, see each functions comment-based
     help for more information.
@@ -34,6 +31,7 @@
   - Change the description of the property RestoreFromRecycleBin.
 - Changes to xADUser
   - Change the description of the property RestoreFromRecycleBin.
+  - Added ServicePrincipalNames property ([issue #153](https://github.com/PowerShell/xActiveDirectory/issues/153)).
 - Changes to xADDomainController
   - Change the `#Requires` statement in the Examples to require the correct
     module.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,10 +32,22 @@
   - Change the description of the property IdentityReference.
 - Changes to xADOrganizationalUnit
   - Change the description of the property RestoreFromRecycleBin.
-- Changes to xADuser
+- Changes to xADUser
   - Change the description of the property RestoreFromRecycleBin.
 - Changes to xADDomainController
-  - Change the `#Requires` statement in the Examples to require the correct module.
+  - Change the `#Requires` statement in the Examples to require the correct
+    module.
+  - Suppressing the Script Analyzer rule `PSAvoidGlobalVars` since the
+    resource is using the `$global:DSCMachineStatus` variable to trigger
+    a reboot.
+- Changes to xADDomain
+  - Suppressing the Script Analyzer rule `PSAvoidGlobalVars` since the
+    resource is using the `$global:DSCMachineStatus` variable to trigger
+    a reboot.
+- Changes to xWaitForADDomain
+  - Suppressing the Script Analyzer rule `PSAvoidGlobalVars` since the
+    resource is using the `$global:DSCMachineStatus` variable to trigger
+    a reboot.
 
 ## 2.26.0.0
 

--- a/DSCResources/MSFT_xADDomain/MSFT_xADDomain.psm1
+++ b/DSCResources/MSFT_xADDomain/MSFT_xADDomain.psm1
@@ -273,6 +273,18 @@ function Test-TargetResource
 
 function Set-TargetResource
 {
+    <#
+        Suppressing this rule because $global:DSCMachineStatus is used to
+        trigger a reboot for the one that was suppressed when calling
+        Install-ADDSForest or Install-ADDSDomains.
+    #>
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidGlobalVars', '')]
+    <#
+        Suppressing this rule because $global:DSCMachineStatus is only set,
+        never used (by design of Desired State Configuration).
+    #>
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '', Scope='Function', Target='DSCMachineStatus')]
+    [CmdletBinding()]
     param
     (
         [Parameter(Mandatory = $true)]

--- a/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
+++ b/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
@@ -168,6 +168,17 @@ function Get-TargetResource
 #>
 function Set-TargetResource
 {
+    <#
+        Suppressing this rule because $global:DSCMachineStatus is used to
+        trigger a reboot for the one that was suppressed when calling
+        Install-ADDSDomainController.
+    #>
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidGlobalVars', '')]
+    <#
+        Suppressing this rule because $global:DSCMachineStatus is only set,
+        never used (by design of Desired State Configuration).
+    #>
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '', Scope='Function', Target='DSCMachineStatus')]
     [CmdletBinding()]
     param
     (


### PR DESCRIPTION
#### Pull Request (PR) description
- Changes to xADDomain
  - Suppressing the Script Analyzer rule `PSAvoidGlobalVars` since the
    resource is using the `$global:DSCMachineStatus` variable to trigger
    a reboot.
- Changes to xADDomainController
  - Suppressing the Script Analyzer rule `PSAvoidGlobalVars` since the
    resource is using the `$global:DSCMachineStatus` variable to trigger
    a reboot.
- Changes to xWaitForADDomain
  - Suppressing the Script Analyzer rule `PSAvoidGlobalVars` since the
    resource is using the `$global:DSCMachineStatus` variable to trigger
    a reboot.

#### This Pull Request (PR) fixes the following issues
- Fixes #286 

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry under the Unreleased section in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xactivedirectory/285)
<!-- Reviewable:end -->
