### PR TITLE
xADUser: Add Additional Parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,14 @@
   - Added ServicePrincipalNames property ([issue #153](https://github.com/PowerShell/xActiveDirectory/issues/153)).
   - Added ChangePasswordAtLogon property ([issue #246](https://github.com/PowerShell/xActiveDirectory/issues/246)).
   - Code cleanup.
+  - Added LogonWorkstations property
+  - Added Organization property
+  - Added OtherName property
+  - Added AccountNotDelegated property
+  - Added AllowReversiblePasswordEncryption property
+  - Added CompoundIdentitySupported property
+  - Added PasswordNotRequired property
+  - Added SmartcardLogonRequired property
 - Changes to xADDomainController
   - Change the `#Requires` statement in the Examples to require the correct
     module.

--- a/DSCResources/MSFT_xADUser/MSFT_xADUser.psm1
+++ b/DSCResources/MSFT_xADUser/MSFT_xADUser.psm1
@@ -137,6 +137,12 @@ $adPropertyMap = @(
         Parameter = 'Manager'
     }
     @{
+         Parameter = 'Organization'
+    }
+    @{
+        Parameter = 'OtherName'
+    }
+    @{
         Parameter          = 'PasswordNeverExpires'
         UseCmdletParameter = $true
     }
@@ -151,6 +157,26 @@ $adPropertyMap = @(
     }
     @{
         Parameter          = 'TrustedForDelegation'
+        UseCmdletParameter = $true
+    }
+    @{
+        Parameter          = 'AccountNotDelegated'
+        UseCmdletParameter = $true
+    }
+    @{
+        Parameter          = 'AllowReversiblePasswordEncryption'
+        UseCmdletParameter = $true
+    }
+    @{
+        Parameter          = 'CompoundIdentitySupported'
+        UseCmdletParameter = $true
+    }
+    @{
+        Parameter          = 'PasswordNotRequired'
+        UseCmdletParameter = $true
+    }
+    @{
+        Parameter          = 'SmartcardLogonRequired'
         UseCmdletParameter = $true
     }
     @{
@@ -397,6 +423,24 @@ function Get-TargetResource
         [System.String]
         $Manager,
 
+        # Specifies the computers that the user can access. (ldapDisplayName 'userWorkStations')
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.String]
+        $LogonWorkstations,
+
+        # Specifies the user's organization (ldapDisplayName 'o')
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.String]
+        $Organization,
+
+        # Specifies a name in addition to a user's given name and surname (ldaDisplayName 'middleName')
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.String]
+        $OtherName,
+
         # Specifies if the account is enabled (default True)
         [Parameter()]
         [ValidateNotNull()]
@@ -426,6 +470,36 @@ function Get-TargetResource
         [ValidateNotNull()]
         [System.Boolean]
         $TrustedForDelegation,
+
+        # Indicates whether the security context of the user is delegated to a service.
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.Boolean]
+        $AccountNotDelegated,
+
+        # Indicates whether reversible password encryption is allowed for the account.
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.Boolean]
+        $AllowReversiblePasswordEncryption,
+
+        # Specifies whether an account supports Kerberos service tickets which includes the authorization data for the user's device.
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.Boolean]
+        $CompoundIdentitySupported,
+
+        # Specifies whether the account requires a password. A password is not required for a new account.
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.Boolean]
+        $PasswordNotRequired,
+
+        # Specifies whether a smart card is required to logon.
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.Boolean]
+        $SmartcardLogonRequired,
 
         # Specifies the Active Directory Domain Services instance to use to perform the task.
         [Parameter()]
@@ -795,6 +869,24 @@ function Test-TargetResource
         [System.String]
         $Manager,
 
+        # Specifies the computers that the user can access. (ldapDisplayName 'userWorkStations')
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.String]
+        $LogonWorkstations,
+
+        # Specifies the user's organization (ldapDisplayName 'o')
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.String]
+        $Organization,
+
+        # Specifies a name in addition to a user's given name and surname (ldaDisplayName 'middleName')
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.String]
+        $OtherName,
+
         # Specifies if the account is enabled (default True)
         [Parameter()]
         [ValidateNotNull()]
@@ -824,6 +916,36 @@ function Test-TargetResource
         [ValidateNotNull()]
         [System.Boolean]
         $TrustedForDelegation,
+
+        # Indicates whether the security context of the user is delegated to a service.
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.Boolean]
+        $AccountNotDelegated,
+
+        # Indicates whether reversible password encryption is allowed for the account.
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.Boolean]
+        $AllowReversiblePasswordEncryption,
+
+        # Specifies whether an account supports Kerberos service tickets which includes the authorization data for the user's device.
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.Boolean]
+        $CompoundIdentitySupported,
+
+        # Specifies whether the account requires a password. A password is not required for a new account.
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.Boolean]
+        $PasswordNotRequired,
+
+        # Specifies whether a smart card is required to logon.
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.Boolean]
+        $SmartcardLogonRequired,
 
         # Specifies the Active Directory Domain Services instance to use to perform the task.
         [Parameter()]
@@ -1181,6 +1303,24 @@ function Set-TargetResource
         [System.String]
         $Manager,
 
+        # Specifies the computers that the user can access. (ldapDisplayName 'userWorkStations')
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.String]
+        $LogonWorkstations,
+
+        # Specifies the user's organization (ldapDisplayName 'o')
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.String]
+        $Organization,
+
+        # Specifies a name in addition to a user's given name and surname (ldaDisplayName 'middleName')
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.String]
+        $OtherName,
+
         # Specifies if the account is enabled (default True)
         [Parameter()]
         [ValidateNotNull()]
@@ -1210,6 +1350,36 @@ function Set-TargetResource
         [ValidateNotNull()]
         [System.Boolean]
         $TrustedForDelegation,
+
+        # Indicates whether the security context of the user is delegated to a service.
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.Boolean]
+        $AccountNotDelegated,
+
+        # Indicates whether reversible password encryption is allowed for the account.
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.Boolean]
+        $AllowReversiblePasswordEncryption,
+
+        # Specifies whether an account supports Kerberos service tickets which includes the authorization data for the user's device.
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.Boolean]
+        $CompoundIdentitySupported,
+
+        # Specifies whether the account requires a password. A password is not required for a new account.
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.Boolean]
+        $PasswordNotRequired,
+
+        # Specifies whether a smart card is required to logon.
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.Boolean]
+        $SmartcardLogonRequired,
 
         # Specifies the Active Directory Domain Services instance to use to perform the task.
         [Parameter()]

--- a/DSCResources/MSFT_xADUser/MSFT_xADUser.schema.mof
+++ b/DSCResources/MSFT_xADUser/MSFT_xADUser.schema.mof
@@ -40,6 +40,9 @@ class MSFT_xADUser : OMI_BaseResource
     [Write, Description("Specifies the user's pager number (ldapDisplayName 'pager')")] String Pager;
     [Write, Description("Specifies the user's IP telephony phone number (ldapDisplayName 'ipPhone')")] String IPPhone;
     [Write, Description("Specifies the user's manager specified as a Distinguished Name (ldapDisplayName 'manager')")] String Manager;
+    [Write, Description("Specifies the computers that the user can access. To specify more than one computer, create a single comma-separated list. You can identify a computer by using the Security Account Manager (SAM) account name (sAMAccountName) or the DNS host name of the computer. The SAM account name is the same as the NetBIOS name of the computer. The LDAP display name (ldapDisplayName) for this property is userWorkStations.")] String LogonWorkstations;
+    [Write, Description("Specifies the user's organization. This parameter sets the Organization property of a user object. The LDAP display name (ldapDisplayName) of this property is o.")] String Organization;
+    [Write, Description("Specifies a name in addition to a user's given name and surname, such as the user's middle name. This parameter sets the OtherName property of a user object. The LDAP display name (ldapDisplayName) of this property is middleName.")] String OtherName;
     [Write, Description("Specifies if the account is enabled (default True)")] Boolean Enabled;
     [Write, Description("Specifies whether the account password can be changed")] Boolean CannotChangePassword;
     [Write, Description("Specifies whether the account password must be changed during the next logon attempt. This cannot be set to true if the PasswordNeverExpires property is also set to true")] Boolean ChangePasswordAtLogon;
@@ -51,5 +54,10 @@ class MSFT_xADUser : OMI_BaseResource
     [Write, Description("Specifies whether an account is trusted for Kerberos delegation (default $false)")] Boolean TrustedForDelegation;
     [Write, Description("Try to restore the user object from the recycle bin before creating a new one.")] Boolean RestoreFromRecycleBin;
     [Write, Description("Specifies the service principal names for the user account.")] String ServicePrincipalNames[];
+    [Write, Description("Indicates whether the security context of the user is delegated to a service.  When this parameter is set to true, the security context of the account is not delegated to a service even when the service account is set as trusted for Kerberos delegation. This parameter sets the AccountNotDelegated property for an Active Directory account. This parameter also sets the ADS_UF_NOT_DELEGATED flag of the Active Directory User Account Control (UAC) attribute.")] Boolean AccountNotDelegated;
+    [Write, Description("Indicates whether reversible password encryption is allowed for the account. This parameter sets the AllowReversiblePasswordEncryption property of the account. This parameter also sets the ADS_UF_ENCRYPTED_TEXT_PASSWORD_ALLOWED flag of the Active Directory User Account Control (UAC) attribute.")] Boolean AllowReversiblePasswordEncryption;
+    [Write, Description("Specifies whether an account supports Kerberos service tickets which includes the authorization data for the user's device. This value sets the compound identity supported flag of the Active Directory msDS-SupportedEncryptionTypes attribute.")] Boolean CompoundIdentitySupported;
+    [Write, Description("Specifies whether the account requires a password. A password is not required for a new account. This parameter sets the PasswordNotRequired property of an account object.")] Boolean PasswordNotRequired;
+    [Write, Description("Specifies whether a smart card is required to logon. This parameter sets the SmartCardLoginRequired property for a user object. This parameter also sets the ADS_UF_SMARTCARD_REQUIRED flag of the Active Directory User Account Control attribute.")] Boolean SmartcardLogonRequired;
     [Read, Description("Returns the X.500 path of the object")] String DistinguishedName;
 };

--- a/Tests/Unit/MSFT_xADUser.Tests.ps1
+++ b/Tests/Unit/MSFT_xADUser.Tests.ps1
@@ -63,9 +63,13 @@ try
             'UserPrincipalName', 'DisplayName', 'Path', 'GivenName', 'Initials', 'Surname', 'Description', 'StreetAddress',
             'POBox', 'City', 'State', 'PostalCode', 'Country', 'Department', 'Division', 'Company', 'Office', 'JobTitle',
             'EmailAddress', 'EmployeeID', 'EmployeeNumber', 'HomeDirectory', 'HomeDrive', 'HomePage', 'ProfilePath',
-            'LogonScript', 'Notes', 'OfficePhone', 'MobilePhone', 'Fax', 'Pager', 'IPPhone', 'HomePhone', 'CommonName'
+            'LogonScript', 'Notes', 'OfficePhone', 'MobilePhone', 'Fax', 'Pager', 'IPPhone', 'HomePhone', 'CommonName',
+            'Manager', 'LogonWorkstations', 'Organization', 'OtherName'
         )
-        $testBooleanProperties = @('PasswordNeverExpires', 'CannotChangePassword', 'ChangePasswordAtLogon', 'TrustedForDelegation', 'Enabled')
+        $testBooleanProperties = @(
+            'PasswordNeverExpires', 'CannotChangePassword', 'TrustedForDelegation', 'Enabled','AccountNotDelegated',
+            'AllowReversiblePasswordEncryption', 'CompoundIdentitySupported', 'PasswordNotRequired', 'SmartcardLogonRequired'
+            )
         $testArrayProperties = @('ServicePrincipalNames')
 
         #region Function Get-TargetResource


### PR DESCRIPTION

#### Pull Request (PR) description

This PR adds the following parameters to the `xADUser` resource:

- AccountNotDelegated
- AllowReversiblePasswordEncryption
- CompoundIdentitySupported
- PasswordNotRequired
- SmartcardLogonRequired
- LogonWorkstations
- Organization
- OtherName

These are all the remaining `String` and `Boolean` parameters available in the `New/Get/Set-ADUser` PowerShell cmdlets.

#### This Pull Request (PR) partly fixes the following issues

None

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry under the Unreleased section in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xactivedirectory/373)
<!-- Reviewable:end -->
