### PR TITLE
xADComputer: Removes helper function Set-DscADComputer

### DIFF
--- a/DSCResources/MSFT_xADComputer/MSFT_xADComputer.psm1
+++ b/DSCResources/MSFT_xADComputer/MSFT_xADComputer.psm1
@@ -958,31 +958,6 @@ function Set-TargetResource
 
 <#
     .SYNOPSIS
-        This is a wrapper for Set-ADComputer.
-
-    .PARAMETER Parameters
-        A hash table containing all parameters that will be passed trough to
-        Set-ADComputer.
-
-    .NOTES
-        This is needed because of how Pester is unable to handle mocking the
-        cmdlet Set-ADComputer.
-#>
-function Set-DscADComputer
-{
-    param
-    (
-        [Parameter(Mandatory = $true)]
-        [System.Collections.Hashtable]
-        $Parameters
-    )
-
-    Set-ADComputer @Parameters |
-        Out-Null
-}
-
-<#
-    .SYNOPSIS
         This evaluates the service principal names current state against the
         desired state.
 


### PR DESCRIPTION
#### Pull Request (PR) description
- Changes to xADComputer
  - Removes the helper function Set-DscADComputer from the resource since it has been moved
    to the module xActiveDirectory.Common.

#### This Pull Request (PR) fixes the following issues
n/a

*There are already entries in the change log that covers this change.*

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [ ] Added an entry under the Unreleased section in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in resource directory README.md.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xactivedirectory/380)
<!-- Reviewable:end -->
