### PR TITLE
xADComputer: Add ActiveDirectory Function and Type Stubs to Tests

### DIFF
--- a/Tests/Unit/MSFT_xADComputer.Tests.ps1
+++ b/Tests/Unit/MSFT_xADComputer.Tests.ps1
@@ -39,6 +39,16 @@ try
     Invoke-TestSetup
 
     InModuleScope $script:dscResourceName {
+        #Load the AD Module Stub, so we can mock the cmdlets, then load the AD types
+        Import-Module (Join-Path -Path $PSScriptRoot -ChildPath 'Stubs\ActiveDirectoryStub.psm1') -Force
+
+        # If one type does not exist, it's assumed the other ones does not exist either.
+        if (-not ('Microsoft.ActiveDirectory.Management.ADComputer' -as [Type]))
+        {
+            $adModuleStub = (Join-Path -Path $PSScriptRoot -ChildPath 'Stubs\Microsoft.ActiveDirectory.Management.cs')
+            Add-Type -Path $adModuleStub
+        }
+
         $mockComputerNamePresent = 'TEST01'
         $mockDomain = 'contoso.com'
         $mockComputerNameAbsent = 'MISSING01'

--- a/Tests/Unit/Stubs/ActiveDirectoryStub.psm1
+++ b/Tests/Unit/Stubs/ActiveDirectoryStub.psm1
@@ -5068,7 +5068,11 @@ function Remove-ADComputer
 
         [Parameter()]
         [string]
-        $Server
+        $Server,
+
+        [Parameter()]
+        [boolean]
+        $Confirm
     )
 
     throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand

--- a/Tests/Unit/Stubs/Microsoft.ActiveDirectory.Management.cs
+++ b/Tests/Unit/Stubs/Microsoft.ActiveDirectory.Management.cs
@@ -26,9 +26,43 @@ namespace Microsoft.ActiveDirectory.Management
         UnknownForest
     }
 
+    public enum ADKerberosEncryptionType
+    {
+        AES128,
+        AES256,
+        DES,
+        None,
+        RC4
+    }
+
+    public enum ADSearchScope
+    {
+        Base,
+        OneLevel,
+        Subtree
+    }
+
+    public class ADAuthenticationPolicy
+    {
+        public ADAuthenticationPolicy():base(){}
+        public ADAuthenticationPolicy(System.String Identity):base(){}
+    }
+
+    public class ADAuthenticationPolicySilo
+    {
+        public ADAuthenticationPolicySilo():base(){}
+        public ADAuthenticationPolicySilo(System.String Identity):base(){}
+    }
+
     public class ADAuthType
     {
         public ADAuthType():base(){}
+    }
+
+    public class ADComputer
+    {
+        public ADComputer():base(){}
+        public ADComputer(System.String Identity):base(){}
     }
 
     public class ADDomain
@@ -47,6 +81,23 @@ namespace Microsoft.ActiveDirectory.Management
     {
         public ADDirectoryServer():base(){}
         public ADDirectoryServer(System.String Identity):base(){}
+    }
+
+    public class ADIdentityNotFoundException : System.Exception
+    {
+        public ADIdentityNotFoundException():base(){}
+    }
+
+    public class ADObject
+    {
+        public ADObject():base(){}
+        public ADObject(System.String Identity):base(){}
+    }
+
+    public class ADPrincipal
+    {
+        public ADPrincipal():base(){}
+        public ADPrincipal(System.String Identity):base(){}
     }
 
     public class ADReplicationSite


### PR DESCRIPTION
#### Pull Request (PR) description

This PR extends the Function and Type stubs that were created for the `xADDomainController` resource tests and adds them into the `xADComputer` resource tests, so that these tests can also be run locally without the `ActiveDirectory` PowerShell module being installed.

#### This Pull Request (PR) fixes the following issues

None

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [ ] Added an entry under the Unreleased section in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in resource directory README.md.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xactivedirectory/387)
<!-- Reviewable:end -->
