### PR TITLE
xADComputer: Fix ServicePrincipalNames Empty String Exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
     Examples folder.
   - Fix the RestoreFromRecycleBin description.
   - Fix unnecessary cast in `Test-TargetResource` ([issue #295](https://github.com/PowerShell/xActiveDirectory/issues/295)).
+  - Fix `ServicePrincipalNames` Empty String Exception ([issue #382](https://github.com/PowerShell/xActiveDirectory/issues/382)).
 - Changes to xADGroup
   - Change the description of the property RestoreFromRecycleBin.
   - Code cleanup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@
     Examples folder.
   - Fix the RestoreFromRecycleBin description.
   - Fix unnecessary cast in `Test-TargetResource` ([issue #295](https://github.com/PowerShell/xActiveDirectory/issues/295)).
-  - Fix `ServicePrincipalNames` Empty String Exception ([issue #382](https://github.com/PowerShell/xActiveDirectory/issues/382)).
+  - Fix ServicePrincipalNames property empty string exception ([issue #382](https://github.com/PowerShell/xActiveDirectory/issues/382)).
 - Changes to xADGroup
   - Change the description of the property RestoreFromRecycleBin.
   - Code cleanup.

--- a/DSCResources/MSFT_xADComputer/MSFT_xADComputer.psm1
+++ b/DSCResources/MSFT_xADComputer/MSFT_xADComputer.psm1
@@ -980,6 +980,7 @@ function Test-ServicePrincipalNames
 
         [Parameter(Mandatory = $true)]
         [AllowEmptyCollection()]
+        [AllowEmptyString()]
         [System.String[]]
         $ServicePrincipalNames
 

--- a/Tests/Unit/MSFT_xADComputer.Tests.ps1
+++ b/Tests/Unit/MSFT_xADComputer.Tests.ps1
@@ -490,66 +490,135 @@ try
 
                 Context 'When a property is not in desired state' {
                     BeforeAll {
-                        # Mock a specific desired state.
-                        Mock -CommandName Get-TargetResource -MockWith $mockGetTargetResource_Present
-
-                        # One test case per property with a value that differs from the desired state.
-                        $testCases_Properties = @(
-                            @{
-                                ParameterName = 'Location'
-                                Value         = 'NewLocation'
-                            },
-                            @{
-                                ParameterName = 'DnsHostName'
-                                Value         = 'New@contoso.com'
-                            },
-                            @{
-                                ParameterName = 'ServicePrincipalNames'
-                                Value         = @('spn/new')
-                            },
-                            @{
-                                ParameterName = 'UserPrincipalName'
-                                Value         = 'New@contoso.com'
-                            },
-                            @{
-                                ParameterName = 'DisplayName'
-                                Value         = 'New'
-                            },
-                            @{
-                                ParameterName = 'Path'
-                                Value         = 'OU=New,CN=Computers,DC=contoso,DC=com'
-                            },
-                            @{
-                                ParameterName = 'Description'
-                                Value         = 'New description'
-                            },
-                            @{
-                                ParameterName = 'Manager'
-                                Value         = 'CN=NewManager,CN=Users,DC=contoso,DC=com'
-                            }
-                        )
+                    # Mock a specific desired state.
+                            Mock -CommandName Get-TargetResource -MockWith $mockGetTargetResource_Present
                     }
 
-                    It 'Should return $false when property <ParameterName> is not in desired state' -TestCases $testCases_Properties {
-                        param
-                        (
-                            [Parameter()]
-                            $ParameterName,
-
-                            [Parameter()]
-                            $Value
-                        )
-
-                        $testTargetResourceParameters = @{
-                            ComputerName   = $mockComputerNamePresent
-                            $ParameterName = $Value
-                            Verbose        = $true
+                    Context 'When a property should be set to a new non-empty value' {
+                        BeforeAll {
+                            # One test case per property with a value that differs from the desired state.
+                            $testCases_Properties = @(
+                                @{
+                                    ParameterName = 'Location'
+                                    Value         = 'NewLocation'
+                                },
+                                @{
+                                    ParameterName = 'DnsHostName'
+                                    Value         = 'New@contoso.com'
+                                },
+                                @{
+                                    ParameterName = 'ServicePrincipalNames'
+                                    Value         = @('spn/new')
+                                },
+                                @{
+                                    ParameterName = 'UserPrincipalName'
+                                    Value         = 'New@contoso.com'
+                                },
+                                @{
+                                    ParameterName = 'DisplayName'
+                                    Value         = 'New'
+                                },
+                                @{
+                                    ParameterName = 'Path'
+                                    Value         = 'OU=New,CN=Computers,DC=contoso,DC=com'
+                                },
+                                @{
+                                    ParameterName = 'Description'
+                                    Value         = 'New description'
+                                },
+                                @{
+                                    ParameterName = 'Manager'
+                                    Value         = 'CN=NewManager,CN=Users,DC=contoso,DC=com'
+                                }
+                            )
                         }
 
-                        $testTargetResourceResult = Test-TargetResource @testTargetResourceParameters
-                        $testTargetResourceResult | Should -BeFalse
+                        It 'Should return $false when non-empty property <ParameterName> is not in desired state' -TestCases $testCases_Properties {
+                            param
+                            (
+                                [Parameter()]
+                                $ParameterName,
 
-                        Assert-MockCalled -CommandName Get-TargetResource -Exactly -Times 1 -Scope It
+                                [Parameter()]
+                                $Value
+                            )
+
+                            $testTargetResourceParameters = @{
+                                ComputerName   = $mockComputerNamePresent
+                                $ParameterName = $Value
+                            }
+
+                            $testTargetResourceResult = Test-TargetResource @testTargetResourceParameters
+                            $testTargetResourceResult | Should -BeFalse
+
+                            Assert-MockCalled -CommandName Get-TargetResource -Exactly -Times 1 -Scope It
+                        }
+
+                    }
+
+                    Context 'When a property should be set to an empty value' {
+                        BeforeAll {
+                            $testCases_Properties = @(
+                                @{
+                                    ParameterName = 'Location'
+                                    Value         = ''
+                                },
+                                @{
+                                    ParameterName = 'DnsHostName'
+                                    Value         = ''
+                                },
+                                @{
+                                    ParameterName = 'ServicePrincipalNames'
+                                    Value         = ''
+                                },
+                                @{
+                                    ParameterName = 'ServicePrincipalNames'
+                                    Value         = @()
+                                },
+                                @{
+                                    ParameterName = 'UserPrincipalName'
+                                    Value         = ''
+                                },
+                                @{
+                                    ParameterName = 'DisplayName'
+                                    Value         = ''
+                                },
+                                @{
+                                    ParameterName = 'Path'
+                                    Value         = ''
+                                },
+                                @{
+                                    ParameterName = 'Description'
+                                    Value         = ''
+                                },
+                                @{
+                                    ParameterName = 'Manager'
+                                    Value         = ''
+                                }
+                            )
+                        }
+
+                        It 'Should return $false when empty property <ParameterName> is not in desired state' -TestCases $testCases_Properties {
+                            param
+                            (
+                                [Parameter()]
+                                $ParameterName,
+
+                                [Parameter()]
+                                $Value
+                            )
+
+                            $testTargetResourceParameters = @{
+                                ComputerName   = $mockComputerNamePresent
+                                $ParameterName = $Value
+                                Verbose        = $true
+                            }
+
+                            $testTargetResourceResult = Test-TargetResource @testTargetResourceParameters
+                            $testTargetResourceResult | Should -BeFalse
+
+                            Assert-MockCalled -CommandName Get-TargetResource -Exactly -Times 1 -Scope It
+                        }
                     }
                 }
             }


### PR DESCRIPTION
#### Pull Request (PR) description

This PR fixes the Exception that occurs when the `ServicePrincipalNames` property is set to an empty string and is not in the desired state.

Additional tests have been added to test all properties being set to empty strings.

#### This Pull Request (PR) fixes the following issues

- Fixes #382 

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry under the Unreleased section in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in resource directory README.md.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xactivedirectory/388)
<!-- Reviewable:end -->
