### PR TITLE
xADUser: Fix Password Property Being Updated Whenever Another Property is Changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,8 @@
   - Added PasswordNotRequired property
   - Added SmartcardLogonRequired property
   - Added ProxyAddresses property ([Issue #254](https://github.com/PowerShell/xActiveDirectory/issues/254)).
+  - Fix Password property being updated whenever another property is changed
+    ([issue #384](https://github.com/PowerShell/xActiveDirectory/issues/384)).
 - Changes to xADDomainController
   - Change the `#Requires` statement in the Examples to require the correct
     module.

--- a/DSCResources/MSFT_xADUser/MSFT_xADUser.psm1
+++ b/DSCResources/MSFT_xADUser/MSFT_xADUser.psm1
@@ -1523,10 +1523,24 @@ function Set-TargetResource
                 elseif ($parameter -eq 'Password' -and $PasswordNeverResets -eq $false)
                 {
                     $adCommonParameters = Get-ADCommonParameters @PSBoundParameters
+                    $testPasswordParams = @{
+                        Username               = $UserName
+                        Password               = $Password
+                        DomainName             = $DomainName
+                        PasswordAuthentication = $PasswordAuthentication
+                    }
 
-                    Write-Verbose -Message ($script:localizedData.SettingADUserPassword -f $UserName)
+                    if ($DomainAdministratorCredential)
+                    {
+                        $testPasswordParams['DomainAdministratorCredential'] = $DomainAdministratorCredential
+                    }
 
-                    Set-ADAccountPassword @adCommonParameters -Reset -NewPassword $Password.Password
+                    if (-not (Test-Password @testPasswordParams))
+                    {
+                        Write-Verbose -Message ($script:localizedData.SettingADUserPassword -f $UserName)
+
+                        Set-ADAccountPassword @adCommonParameters -Reset -NewPassword $Password.Password
+                    }
                 }
                 elseif ($parameter -eq 'Enabled' -and ($PSBoundParameters.$parameter -ne $targetResource.$parameter))
                 {

--- a/Tests/Unit/MSFT_xADUser.Tests.ps1
+++ b/Tests/Unit/MSFT_xADUser.Tests.ps1
@@ -490,6 +490,7 @@ try
                 Mock -CommandName Get-ADUser -MockWith { return $fakeADUser }
                 Mock -CommandName Set-ADUser
                 Mock -CommandName Set-ADAccountPassword -ParameterFilter { $NewPassword -eq $testCredential.Password }
+                Mock -CommandName Test-Password -MockWith { $false }
 
                 Set-TargetResource @testPresentParams -Password $testCredential
 
@@ -502,6 +503,17 @@ try
                 Mock -CommandName Set-ADAccountPassword
 
                 Set-TargetResource @testPresentParams -Password $testCredential -PasswordNeverResets $true
+
+                Assert-MockCalled -CommandName Set-ADAccountPassword -Scope It -Times 0
+            }
+
+            It "Does not call 'Set-ADAccountPassword' when 'Password' parameter is specified and is in the desired state" {
+                Mock -CommandName Get-ADUser -MockWith { return $fakeADUser }
+                Mock -CommandName Set-ADUser
+                Mock -CommandName Set-ADAccountPassword
+                Mock -CommandName Test-Password -MockWith { $true }
+
+                Set-TargetResource @testPresentParams -Password $testCredential
 
                 Assert-MockCalled -CommandName Set-ADAccountPassword -Scope It -Times 0
             }

--- a/Tests/Unit/MSFT_xADUser.Tests.ps1
+++ b/Tests/Unit/MSFT_xADUser.Tests.ps1
@@ -518,6 +518,17 @@ try
                 Assert-MockCalled -CommandName Set-ADAccountPassword -Scope It -Times 0
             }
 
+            It "Calls 'Test-Password' with the correct parameters when 'DomainAdministratorCredential' is specified" {
+                Mock -CommandName Get-ADUser -MockWith { return $fakeADUser }
+                Mock -CommandName Set-ADUser
+                Mock -CommandName Set-ADAccountPassword -ParameterFilter { $NewPassword -eq $testCredential.Password }
+                Mock -CommandName Test-Password -ParameterFilter { $DomainAdministratorCredential -eq $testCredential } -MockWith { $true }
+
+                Set-TargetResource @testPresentParams -Password $testCredential -DomainAdministratorCredential $testCredential
+
+                Assert-MockCalled -CommandName Test-Password -ParameterFilter { $DomainAdministratorCredential -eq $testCredential } -Scope It -Exactly 1
+            }
+
             It "Should call 'Set-ADUser' with 'Replace' when existing mismatched AD property is null" {
                 $testADPropertyName = 'Description'
                 Mock -CommandName Get-ADUser -MockWith {


### PR DESCRIPTION
#### Pull Request (PR) description

This PR fixes the issue that  `Password` property is being updated whenever another property is changed even though it was already in the desired state.

This is achieved by adding a call to the `Test-Password` function from within the relevant code block of the `Set-TargetResource` function.

#### This Pull Request (PR) fixes the following issues

- Fixes #384 

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [ ] Added an entry under the Unreleased section in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in resource directory README.md.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xactivedirectory/389)
<!-- Reviewable:end -->
