### PR TITLE
xADUser: Replace Write-Error with the correct helper function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@
   - Added ProxyAddresses property ([Issue #254](https://github.com/PowerShell/xActiveDirectory/issues/254)).
   - Fix Password property being updated whenever another property is changed
     ([issue #384](https://github.com/PowerShell/xActiveDirectory/issues/384)).
+  - Replace Write-Error with the correct helper function ([Issue #331](https://github.com/PowerShell/xActiveDirectory/issues/331)).
 - Changes to xADDomainController
   - Change the `#Requires` statement in the Examples to require the correct
     module.

--- a/DSCResources/MSFT_xADUser/MSFT_xADUser.psm1
+++ b/DSCResources/MSFT_xADUser/MSFT_xADUser.psm1
@@ -588,8 +588,8 @@ function Get-TargetResource
     }
     catch
     {
-        Write-Error -Message ($script:localizedData.RetrievingADUserError -f $UserName, $DomainName)
-        throw $_
+        $errorMessage = $script:localizedData.RetrievingADUserError -f $UserName, $DomainName
+        New-InvalidOperationException -Message $errorMessage -ErrorRecord $_
     }
 
     $targetResource = @{

--- a/Tests/Unit/MSFT_xADUser.Tests.ps1
+++ b/Tests/Unit/MSFT_xADUser.Tests.ps1
@@ -69,7 +69,7 @@ try
         $testBooleanProperties = @(
             'PasswordNeverExpires', 'CannotChangePassword', 'ChangePasswordAtLogon', 'TrustedForDelegation', 'Enabled','AccountNotDelegated',
             'AllowReversiblePasswordEncryption', 'CompoundIdentitySupported', 'PasswordNotRequired', 'SmartcardLogonRequired'
-            )
+        )
         $testArrayProperties = @('ServicePrincipalNames', 'ProxyAddresses')
 
         #region Function Get-TargetResource
@@ -96,6 +96,13 @@ try
                 $adUser = Get-TargetResource @testPresentParams
 
                 $adUser.Ensure | Should -Be 'Absent'
+            }
+
+            It "Should throw the correct exception when Get-ADUser returns an unknown error" {
+                Mock -CommandName Get-ADUser -MockWith { throw }
+
+                $expectedError = $script:localizedData.RetrievingADUserError -f $testPresentParams.UserName, $testPresentParams.DomainName
+                { Get-TargetResource @testPresentParams } | Should -Throw $expectedError
             }
 
             It "Calls 'Get-ADUser' with 'Server' parameter when 'DomainController' specified" {


### PR DESCRIPTION
#### Pull Request (PR) description

This PR replaces the `Write-Error` statement in the `xADUser` resource with a call to the resource helper function `New-InvalidOperationException` and a relevant test added.

#### This Pull Request (PR) fixes the following issues

- Fixes #331

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry under the Unreleased section in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in resource directory README.md.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xactivedirectory/392)
<!-- Reviewable:end -->
