### PR TITLE
xADRecycleBin: Replace Write-Error with the correct helper function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,7 +115,7 @@
   - Code cleanup.
   - It now sets back the `$ErrorActionPreference` that was set prior to
     setting it to `'Stop'`.
-  - Replace Write-Error with the correct helper function.
+  - Replace Write-Error with the correct helper function ([issue #327](https://github.com/PowerShell/xActiveDirectory/issues/327)).
 - Changes to xADReplicationSiteLink
   - Fix ADIdentityNotFoundException when creating a new site link.
   - Code cleanup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,8 +113,9 @@
   - Remove unneeded example and resource designer files.
   - Added missing property schema descriptions ([issue #368](https://github.com/PowerShell/xActiveDirectory/issues/368)).
   - Code cleanup.
-  - It now set back the `$ErrorActionPreference` that was set prior to
+  - It now sets back the `$ErrorActionPreference` that was set prior to
     setting it to `'Stop'`.
+  - Replace Write-Error with the correct helper function.
 - Changes to xADReplicationSiteLink
   - Fix ADIdentityNotFoundException when creating a new site link.
   - Code cleanup.

--- a/DSCResources/MSFT_xADRecycleBin/MSFT_xADRecycleBin.psm1
+++ b/DSCResources/MSFT_xADRecycleBin/MSFT_xADRecycleBin.psm1
@@ -46,18 +46,18 @@ function Get-TargetResource
     }
     catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException], [Microsoft.ActiveDirectory.Management.ADServerDownException]
     {
-        Write-Error -Message ($script:localizedData.ForestNotFound -f $ForestFQDN)
-        throw $_
+        $errorMessage = $script:localizedData.ForestNotFound -f $ForestFQDN
+        New-ObjectNotFoundException -Message $errorMessage -ErrorRecord $_
     }
     catch [System.Security.Authentication.AuthenticationException]
     {
-        Write-Error -Message $script:localizedData.CredentialError
-        throw $_
+        $errorMessage = $script:localizedData.CredentialError
+        New-InvalidArgumentException -Message $errorMessage -ErrorRecord $_
     }
     catch
     {
-        Write-Error -Message ($script:localizedData.GetUnhandledException -f $ForestFQDN)
-        throw $_
+        $errorMessage = $script:localizedData.GetUnhandledException -f $ForestFQDN
+        New-InvalidOperationException -Message $errorMessage -ErrorRecord $_
     }
     finally
     {
@@ -112,18 +112,18 @@ function Set-TargetResource
     }
     catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException], [Microsoft.ActiveDirectory.Management.ADServerDownException]
     {
-        Write-Error -Message ($script:localizedData.ForestNotFound -f $ForestFQDN)
-        throw $_
+        $errorMessage = $script:localizedData.ForestNotFound -f $ForestFQDN
+        New-ObjectNotFoundException -Message $errorMessage -ErrorRecord $_
     }
     catch [System.Security.Authentication.AuthenticationException]
     {
-        Write-Error -Message $script:localizedData.CredentialError
-        throw $_
+        $errorMessage = $script:localizedData.CredentialError
+        New-InvalidArgumentException -Message $errorMessage -ErrorRecord $_
     }
     catch
     {
-        Write-Error -Message ($script:localizedData.SetUnhandledException -f $ForestFQDN)
-        throw $_
+        $errorMessage = $script:localizedData.SetUnhandledException -f $ForestFQDN
+        New-InvalidOperationException -Message $errorMessage -ErrorRecord $_
     }
     finally
     {
@@ -171,18 +171,18 @@ function Test-TargetResource
     }
     catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException], [Microsoft.ActiveDirectory.Management.ADServerDownException]
     {
-        Write-Error -Message ($script:localizedData.ForestNotFound -f $ForestFQDN)
-        throw $_
+        $errorMessage = $script:localizedData.ForestNotFound -f $ForestFQDN
+        New-ObjectNotFoundException -Message $errorMessage -ErrorRecord $_
     }
     catch [System.Security.Authentication.AuthenticationException]
     {
-        Write-Error -Message $script:localizedData.CredentialError
-        throw $_
+        $errorMessage = $script:localizedData.CredentialError
+        New-InvalidArgumentException -Message $errorMessage -ErrorRecord $_
     }
     catch
     {
-        Write-Error -Message ($script:localizedData.TestUnhandledException -f $ForestFQDN)
-        throw $_
+        $errorMessage = $script:localizedData.SetUnhandledException -f $ForestFQDN
+        New-InvalidOperationException -Message $errorMessage -ErrorRecord $_
     }
     finally
     {

--- a/DSCResources/MSFT_xADRecycleBin/MSFT_xADRecycleBin.psm1
+++ b/DSCResources/MSFT_xADRecycleBin/MSFT_xADRecycleBin.psm1
@@ -52,7 +52,7 @@ function Get-TargetResource
     catch [System.Security.Authentication.AuthenticationException]
     {
         $errorMessage = $script:localizedData.CredentialError
-        New-InvalidArgumentException -Message $errorMessage -ErrorRecord $_
+        New-InvalidArgumentException -Message $errorMessage -ArgumentName 'EnterpriseAdministratorCredential'
     }
     catch
     {
@@ -118,7 +118,7 @@ function Set-TargetResource
     catch [System.Security.Authentication.AuthenticationException]
     {
         $errorMessage = $script:localizedData.CredentialError
-        New-InvalidArgumentException -Message $errorMessage -ErrorRecord $_
+        New-InvalidArgumentException -Message $errorMessage -ArgumentName 'EnterpriseAdministratorCredential'
     }
     catch
     {
@@ -177,11 +177,11 @@ function Test-TargetResource
     catch [System.Security.Authentication.AuthenticationException]
     {
         $errorMessage = $script:localizedData.CredentialError
-        New-InvalidArgumentException -Message $errorMessage -ErrorRecord $_
+        New-InvalidArgumentException -Message $errorMessage -ArgumentName 'EnterpriseAdministratorCredential'
     }
     catch
     {
-        $errorMessage = $script:localizedData.SetUnhandledException -f $ForestFQDN
+        $errorMessage = $script:localizedData.TestUnhandledException -f $ForestFQDN
         New-InvalidOperationException -Message $errorMessage -ErrorRecord $_
     }
     finally

--- a/Tests/Unit/MSFT_xADRecycleBin.Tests.ps1
+++ b/Tests/Unit/MSFT_xADRecycleBin.Tests.ps1
@@ -141,7 +141,7 @@ try
                     Mock -CommandName Get-ADObject -MockWith {
                         throw Unhandled.Exception
                     }
-                    $expectedError = $script:localizedData.TestUnhandledException -f $ForestFQDN
+                    $expectedError = $script:localizedData.GetUnhandledException -f $ForestFQDN
                     { Get-TargetResource @targetResourceParameters } | Should -Throw $expectedError
                 }
             }
@@ -261,7 +261,7 @@ try
                     Mock -CommandName Get-ADForest -MockWith {
                         throw Unhandled.Exception
                     }
-                    $expectedError = $script:localizedData.TestUnhandledException -f $ForestFQDN
+                    $expectedError = $script:localizedData.SetUnhandledException -f $ForestFQDN
                     { Set-TargetResource @targetResourceParameters } | Should -Throw $expectedError
                 }
             }

--- a/Tests/Unit/MSFT_xADRecycleBin.Tests.ps1
+++ b/Tests/Unit/MSFT_xADRecycleBin.Tests.ps1
@@ -114,23 +114,35 @@ try
                 Mock -CommandName Write-Error
 
                 It 'Should throw ADIdentityNotFoundException' {
-                    Mock -CommandName Get-ADObject -MockWith { throw (New-Object -TypeName Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException) }
-                    { Get-TargetResource @targetResourceParameters } | Should -Throw Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException
+                    Mock -CommandName Get-ADObject -MockWith {
+                        throw (New-Object -TypeName Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException)
+                    }
+                    $expectedError = $script:localizedData.ForestNotFound -f $ForestFQDN
+                    { Get-TargetResource @targetResourceParameters } | Should -Throw $expectedError
                 }
 
                 It 'Should throw ADServerDownException' {
-                    Mock -CommandName Get-ADObject -MockWith { throw (New-Object -TypeName Microsoft.ActiveDirectory.Management.ADServerDownException) }
-                    { Get-TargetResource @targetResourceParameters } | Should -Throw Microsoft.ActiveDirectory.Management.ADServerDownException
+                    Mock -CommandName Get-ADObject -MockWith {
+                        throw (New-Object -TypeName Microsoft.ActiveDirectory.Management.ADServerDownException)
+                    }
+                    $expectedError = $script:localizedData.ForestNotFound -f $ForestFQDN
+                    { Get-TargetResource @targetResourceParameters } | Should -Throw $expectedError
                 }
 
                 It 'Should throw AuthenticationException' {
-                    Mock -CommandName Get-ADObject -MockWith { throw (New-Object -TypeName System.Security.Authentication.AuthenticationException) }
-                    { Get-TargetResource @targetResourceParameters } | Should -Throw 'System error'
+                    Mock -CommandName Get-ADObject -MockWith {
+                        throw (New-Object -TypeName System.Security.Authentication.AuthenticationException)
+                    }
+                    $expectedError = $script:localizedData.CredentialError
+                    { Get-TargetResource @targetResourceParameters } | Should -Throw $expectedError
                 }
 
                 It 'Should throw UnhandledException' {
-                    Mock -CommandName Get-ADObject -MockWith { throw Unhandled.Exception }
-                    { Get-TargetResource @targetResourceParameters } | Should -Throw Unhandled.Exception
+                    Mock -CommandName Get-ADObject -MockWith {
+                        throw Unhandled.Exception
+                    }
+                    $expectedError = $script:localizedData.TestUnhandledException -f $ForestFQDN
+                    { Get-TargetResource @targetResourceParameters } | Should -Throw $expectedError
                 }
             }
         }
@@ -158,23 +170,35 @@ try
                 Mock -CommandName Write-Error
 
                 It 'Should throw ADIdentityNotFoundException' {
-                    Mock -CommandName Get-ADObject -MockWith { throw (New-Object -TypeName Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException) }
-                    { Test-TargetResource @targetResourceParameters } | Should -Throw Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException
+                    Mock -CommandName Get-ADObject -MockWith {
+                        throw (New-Object -TypeName Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException)
+                    }
+                    $expectedError = $script:localizedData.ForestNotFound -f $ForestFQDN
+                    { Test-TargetResource @targetResourceParameters } | Should -Throw $expectedError
                 }
 
                 It 'Should throw ADServerDownException' {
-                    Mock -CommandName Get-ADObject -MockWith { throw (New-Object -TypeName Microsoft.ActiveDirectory.Management.ADServerDownException) }
-                    { Test-TargetResource @targetResourceParameters } | Should -Throw Microsoft.ActiveDirectory.Management.ADServerDownException
+                    Mock -CommandName Get-ADObject -MockWith {
+                        throw (New-Object -TypeName Microsoft.ActiveDirectory.Management.ADServerDownException)
+                    }
+                    $expectedError = $script:localizedData.ForestNotFound -f $ForestFQDN
+                    { Test-TargetResource @targetResourceParameters } | Should -Throw $expectedError
                 }
 
                 It 'Should throw AuthenticationException' {
-                    Mock -CommandName Get-ADObject -MockWith { throw (New-Object -TypeName System.Security.Authentication.AuthenticationException) }
-                    { Test-TargetResource @targetResourceParameters } | Should -Throw 'System error'
+                    Mock -CommandName Get-ADObject -MockWith {
+                        throw (New-Object -TypeName System.Security.Authentication.AuthenticationException)
+                    }
+                    $expectedError = $script:localizedData.CredentialError
+                    { Test-TargetResource @targetResourceParameters } | Should -Throw $expectedError
                 }
 
                 It 'Should throw UnhandledException' {
-                    Mock -CommandName Get-ADObject -MockWith { throw Unhandled.Exception }
-                    { Test-TargetResource @targetResourceParameters } | Should -Throw Unhandled.Exception
+                    Mock -CommandName Get-ADObject -MockWith {
+                        throw Unhandled.Exception
+                    }
+                    $expectedError = $script:localizedData.TestUnhandledException -f $ForestFQDN
+                    { Test-TargetResource @targetResourceParameters } | Should -Throw $expectedError
                 }
             }
         }
@@ -210,23 +234,35 @@ try
                 Mock -CommandName Write-Error
 
                 It 'Should throw ADIdentityNotFoundException' {
-                    Mock -CommandName Get-ADForest -MockWith { throw (New-Object -TypeName Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException) }
-                    { Set-TargetResource @targetResourceParameters } | Should -Throw Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException
+                    Mock -CommandName Get-ADForest -MockWith {
+                        throw (New-Object -TypeName Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException)
+                    }
+                    $expectedError = $script:localizedData.ForestNotFound -f $ForestFQDN
+                    { Set-TargetResource @targetResourceParameters } | Should -Throw $expectedError
                 }
 
                 It 'Should throw ADServerDownException' {
-                    Mock -CommandName Get-ADForest -MockWith { throw (New-Object -TypeName Microsoft.ActiveDirectory.Management.ADServerDownException) }
-                    { Set-TargetResource @targetResourceParameters } | Should -Throw Microsoft.ActiveDirectory.Management.ADServerDownException
+                    Mock -CommandName Get-ADForest -MockWith {
+                        throw (New-Object -TypeName Microsoft.ActiveDirectory.Management.ADServerDownException)
+                    }
+                    $expectedError = $script:localizedData.ForestNotFound -f $ForestFQDN
+                    { Set-TargetResource @targetResourceParameters } | Should -Throw $expectedError
                 }
 
                 It 'Should throw AuthenticationException' {
-                    Mock -CommandName Get-ADForest -MockWith { throw (New-Object -TypeName System.Security.Authentication.AuthenticationException) }
-                    { Set-TargetResource @targetResourceParameters } | Should -Throw 'System error'
+                    Mock -CommandName Get-ADForest -MockWith {
+                        throw (New-Object -TypeName System.Security.Authentication.AuthenticationException)
+                    }
+                    $expectedError = $script:localizedData.CredentialError
+                    { Set-TargetResource @targetResourceParameters } | Should -Throw $expectedError
                 }
 
                 It 'Should throw UnhandledException' {
-                    Mock -CommandName Get-ADForest -MockWith { throw Unhandled.Exception }
-                    { Set-TargetResource @targetResourceParameters } | Should -Throw Unhandled.Exception
+                    Mock -CommandName Get-ADForest -MockWith {
+                        throw Unhandled.Exception
+                    }
+                    $expectedError = $script:localizedData.TestUnhandledException -f $ForestFQDN
+                    { Set-TargetResource @targetResourceParameters } | Should -Throw $expectedError
                 }
             }
         }


### PR DESCRIPTION
#### Pull Request (PR) description

This PR replaces the `Write-Error` statements in the `xADRecycleBin` resource with calls to the relevant resource helper exception functions.

#### This Pull Request (PR) fixes the following issues

- Fixes #327 

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry under the Unreleased section in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in resource directory README.md.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xactivedirectory/393)
<!-- Reviewable:end -->
