### PR TITLE
xADOrganizationalUnit: Verbose Message Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
 - Changes to xADOrganizationalUnit
   - Change the description of the property RestoreFromRecycleBin.
   - Code cleanup.
+  - Fix incorrect verbose message when this resource has Ensure set to Absent ([issue #276](https://github.com/PowerShell/xActiveDirectory/issues/276)).
 - Changes to xADUser
   - Change the description of the property RestoreFromRecycleBin.
   - Added ServicePrincipalNames property ([issue #153](https://github.com/PowerShell/xActiveDirectory/issues/153)).

--- a/DSCResources/MSFT_xADOrganizationalUnit/MSFT_xADOrganizationalUnit.psm1
+++ b/DSCResources/MSFT_xADOrganizationalUnit/MSFT_xADOrganizationalUnit.psm1
@@ -133,7 +133,7 @@ function Test-TargetResource
         else
         {
             $isCompliant = $true
-            Write-Verbose ($script:localizedData.OUInDesiredState -f $targetResource.Name)
+            Write-Verbose ($script:localizedData.OUDoesNotExistAndShouldNot -f $targetResource.Name)
         }
     }
 

--- a/DSCResources/MSFT_xADOrganizationalUnit/en-US/MSFT_xADOrganizationalUnit.strings.psd1
+++ b/DSCResources/MSFT_xADOrganizationalUnit/en-US/MSFT_xADOrganizationalUnit.strings.psd1
@@ -1,12 +1,13 @@
 # culture="en-US"
 ConvertFrom-StringData @'
-    RetrievingOU             = Retrieving OU '{0}'.
-    UpdatingOU               = Updating OU '{0}'.
-    DeletingOU               = Deleting OU '{0}'.
-    CreatingOU               = Creating OU '{0}'.
-    RestoringOU              = Attempting to restore the organizational unit object {0} from the recycle bin.
-    OUInDesiredState         = OU '{0}' exists and is in the desired state.
-    OUNotInDesiredState      = OU '{0}' exists but is not in the desired state.
-    OUExistsButShouldNot     = OU '{0}' exists when it should not exist.
-    OUDoesNotExistButShould  = OU '{0}' does not exist when it should exist.
+    RetrievingOU               = Retrieving OU '{0}'.
+    UpdatingOU                 = Updating OU '{0}'.
+    DeletingOU                 = Deleting OU '{0}'.
+    CreatingOU                 = Creating OU '{0}'.
+    RestoringOU                = Attempting to restore the organizational unit object {0} from the recycle bin.
+    OUInDesiredState           = OU '{0}' exists and is in the desired state.
+    OUNotInDesiredState        = OU '{0}' exists but is not in the desired state.
+    OUExistsButShouldNot       = OU '{0}' exists when it should not exist.
+    OUDoesNotExistButShould    = OU '{0}' does not exist when it should exist.
+    OUDoesNotExistAndShouldNot = OU '{0}' does not exist and is in the desired state.
 '@


### PR DESCRIPTION
#### Pull Request (PR) description

This PR fixes the incorrect verbose message when this resource has `Ensure` set to `Absent`.

#### This Pull Request (PR) fixes the following issues

- Fixes #276

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry under the Unreleased section in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in resource directory README.md.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xactivedirectory/396)
<!-- Reviewable:end -->
