### PR TITLE
xADDomainController: Add RODC Creation Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,8 @@
 - Changes to xWaitForADDomain
   - Added comment-based help ([issue #341](https://github.com/PowerShell/xActiveDirectory/issues/341))
 - Changes to xAdDomainController
-  - Add RODC Creation Support
+  - Add support for creating Read-Only Domain Controller (RODC)
+    ([issue #40](https://github.com/PowerShell/xActiveDirectory/issues/40)).
 
 ## 3.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@
   - Added integration tests ([issue #348](https://github.com/PowerShell/xActiveDirectory/issues/348)).
 - Changes to xWaitForADDomain
   - Added comment-based help ([issue #341](https://github.com/PowerShell/xActiveDirectory/issues/341))
+- Changes to xAdDomainController
+  - Add RODC Creation Support
 
 ## 3.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 - Changes to xAdDomainController
   - Add support for creating Read-Only Domain Controller (RODC)
     ([issue #40](https://github.com/PowerShell/xActiveDirectory/issues/40)).
+    [Svilen @SSvilen](https://github.com/SSvilen)
   - Refactored unit tests for Test-TargetResource.
 
 ## 3.0.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 - Changes to xAdDomainController
   - Add support for creating Read-Only Domain Controller (RODC)
     ([issue #40](https://github.com/PowerShell/xActiveDirectory/issues/40)).
+  - Refactored unit tests for Test-TargetResource.
 
 ## 3.0.0.0
 

--- a/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
+++ b/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
@@ -609,13 +609,13 @@ function Test-TargetResource
 
     $testTargetResourceReturnValue = $existingResource.Ensure
 
-    # if ($PSBoundParameters.ContainsKey('ReadOnlyReplica') -and $ReadOnlyReplica)
-    # {
-    #     if ($testTargetResourceReturnValue -and -not $testTargetResourceReturnValue.ReadOnlyReplica)
-    #     {
-    #         New-InvalidOperationException -Message $script:localizedData.CannotConvertToRODC
-    #     }
-    # }
+    if ($PSBoundParameters.ContainsKey('ReadOnlyReplica') -and $ReadOnlyReplica)
+    {
+        if ($testTargetResourceReturnValue -and -not $testTargetResourceReturnValue.ReadOnlyReplica)
+        {
+            New-InvalidOperationException -Message $script:localizedData.CannotConvertToRODC
+        }
+    }
 
     if ($PSBoundParameters.ContainsKey('SiteName') -and $existingResource.SiteName -ne $SiteName)
     {

--- a/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
+++ b/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
@@ -380,7 +380,7 @@ function Set-TargetResource
         {
             $testMembersParameters = @{
                 ExistingMembers = $targetResource.AllowPasswordReplicationAccountName
-                Members         = $AllowPasswordReplicationAccountName;
+                Members         = $AllowPasswordReplicationAccountName
             }
 
             if (-not (Test-Members @testMembersParameters))

--- a/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
+++ b/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
@@ -406,7 +406,7 @@ function Set-TargetResource
                         AllowedList = $adPrincipalsToRemove
                     }
 
-                    Remove-ADDomainControllerPasswordReplicationPolicy @removeADPasswordReplicationPolicy
+                    Remove-ADDomainControllerPasswordReplicationPolicy @removeADPasswordReplicationPolicy -Confirm:$false
                 }
 
                 if ($null -ne $adPrincipalsToAdd)
@@ -453,7 +453,7 @@ function Set-TargetResource
                         DeniedList  = $adPrincipalsToRemove
                     }
 
-                    Remove-ADDomainControllerPasswordReplicationPolicy @removeADPasswordReplicationPolicy
+                    Remove-ADDomainControllerPasswordReplicationPolicy @removeADPasswordReplicationPolicy -Confirm:$false
                 }
 
                 if ($null -ne $adPrincipalsToAdd)

--- a/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
+++ b/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
@@ -74,6 +74,9 @@ function Get-TargetResource
         DomainName           = $DomainName
         Ensure               = $false
         IsGlobalCatalog      = $false
+        ReadOnlyReplica      = $false
+        AllowPasswordReplicationAccountName = $null
+        DenyPasswordReplicationAccountName = $null
     }
 
     Write-Verbose -Message (
@@ -105,8 +108,8 @@ function Get-TargetResource
             $script:localizedData.AlreadyDomainController -f $domainControllerObject.Name, $domainControllerObject.Domain
         )
 
-        $allowedPasswordReplicationAccountName = Get-ADDomainControllerPasswordReplicationPolicy -Allowed -Identity $domainControllerObject | ForEach-Object -MemberName sAMAccountName
-        $deniedPasswordReplicationAccountName = Get-ADDomainControllerPasswordReplicationPolicy -Denied -Identity $domainControllerObject | ForEach-Object -MemberName sAMAccountName
+        $allowedPasswordReplicationAccountName = [System.String[]] (Get-ADDomainControllerPasswordReplicationPolicy -Allowed -Identity $domainControllerObject | ForEach-Object -MemberName sAMAccountName)
+        $deniedPasswordReplicationAccountName = [System.String[]] (Get-ADDomainControllerPasswordReplicationPolicy -Denied -Identity $domainControllerObject | ForEach-Object -MemberName sAMAccountName)
         $serviceNTDS = Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\NTDS\Parameters'
         $serviceNETLOGON = Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\Netlogon\Parameters'
 
@@ -117,6 +120,7 @@ function Get-TargetResource
         $getTargetResourceResult.SiteName = $domainControllerObject.Site
         $getTargetResourceResult.IsGlobalCatalog = $domainControllerObject.IsGlobalCatalog
         $getTargetResourceResult.DomainName = $domainControllerObject.Domain
+        $getTargetResourceResult.ReadOnlyReplica = $domainControllerObject.IsReadOnly
         $getTargetResourceResult.AllowPasswordReplicationAccountName = $allowedPasswordReplicationAccountName
         $getTargetResourceResult.DenyPasswordReplicationAccountName = $deniedPasswordReplicationAccountName
     }
@@ -170,7 +174,7 @@ function Get-TargetResource
     .PARAMETER AllowPasswordReplicationAccountName
         Provides a list of the users, computers, and groups to add to the password replication allowed list.
 
-    .PARAMETER AllowPasswordReplicationAccountName
+    .PARAMETER DenyPasswordReplicationAccountName
         Provides a list of the users, computers, and groups to add to the password replication denied list.
 #>
 function Set-TargetResource
@@ -520,7 +524,7 @@ function Set-TargetResource
     .PARAMETER AllowPasswordReplicationAccountName
         Provides a list of the users, computers, and groups to add to the password replication allowed list.
 
-    .PARAMETER AllowPasswordReplicationAccountName
+    .PARAMETER DenyPasswordReplicationAccountName
         Provides a list of the users, computers, and groups to add to the password replication denied list.
 #>
 function Test-TargetResource

--- a/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
+++ b/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.psm1
@@ -731,8 +731,8 @@ function Get-MembersToAddAndRemove
     }
 
     return @{
-        MembersToAdd = $principalsToAdd
-        MembersToRemove =  $principalsToRemove
+        MembersToAdd = [Microsoft.ActiveDirectory.Management.ADPrincipal[]] $principalsToAdd
+        MembersToRemove =  [Microsoft.ActiveDirectory.Management.ADPrincipal[]] $principalsToRemove
     }
 }
 

--- a/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.schema.mof
+++ b/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.schema.mof
@@ -11,4 +11,7 @@ class MSFT_xADDomainController : OMI_BaseResource
     [Write, Description("The path of the media you want to use install the Domain Controller.")] String InstallationMediaPath;
     [Write, Description("Specifies if the domain controller will be a Global Catalog (GC).")] Boolean IsGlobalCatalog;
     [Read, Description("Returns the state of the Domain Controller.")] String Ensure;
+    [Write, Description("Indicates that the cmdlet installs the domain controller as an Read-Only Domain Controller (RODC) for an existing domain.")] Boolean ReadOnlyReplica;
+    [Write, Description("Specifies an array of names of user accounts, group accounts, and computer accounts whose passwords can be replicated to this Read-Only Domain Controller (RODC).")] String AllowPasswordReplicationAccountName[];
+    [Write, Description("Specifies the names of user accounts, group accounts, and computer accounts whose passwords are not to be replicated to this Read-Only Domain Controller (RODC).")] String DenyPasswordReplicationAccountName[];
 };

--- a/DSCResources/MSFT_xADDomainController/README.md
+++ b/DSCResources/MSFT_xADDomainController/README.md
@@ -1,8 +1,8 @@
 # Description
 
 The xADDomainController DSC resource will install and configure domain
-controllers in Active Directory.Installation of Read Only domain controllers
-is also supported.
+controllers in Active Directory. Installation of Read-Only Domain Controllers
+(RODC) is also supported.
 
 >**Note:** If the account used for the parameter `DomainAdministratorCredential`
 >cannot connect to another domain controller, for example using a credential

--- a/DSCResources/MSFT_xADDomainController/README.md
+++ b/DSCResources/MSFT_xADDomainController/README.md
@@ -1,7 +1,8 @@
 # Description
 
 The xADDomainController DSC resource will install and configure domain
-controllers in Active Directory.
+controllers in Active Directory.Installation of Read Only domain controllers
+is also supported.
 
 >**Note:** If the account used for the parameter `DomainAdministratorCredential`
 >cannot connect to another domain controller, for example using a credential

--- a/DSCResources/MSFT_xADDomainController/en-US/MSFT_xADDomainController.strings.psd1
+++ b/DSCResources/MSFT_xADDomainController/en-US/MSFT_xADDomainController.strings.psd1
@@ -19,5 +19,5 @@ ConvertFrom-StringData @'
     ExpectedGlobalCatalogDisabled = The domain controller have a Global Catalog, but it was expected to not have a Global Catalog. (ADDC0019)
     AllowedSyncAccountsMismatch   = There is a mismatch in AllowPasswordReplicationAccountName list. Got {0}, expected was {1}. (ADDC0020)
     DenySyncAccountsMismatch      = There is a mismatch in DenyPasswordReplicationAccountName list. Got {0}, expected was {1}. (ADDC0021)
-    RODCMissingSite               = You have specified 'ReadonlyReplica', but did not provide a site name. (ADDC0022)
+    RODCMissingSite               = You have specified 'ReadOnlyReplica', but did not provide a site name. (ADDC0022)
 '@

--- a/DSCResources/MSFT_xADDomainController/en-US/MSFT_xADDomainController.strings.psd1
+++ b/DSCResources/MSFT_xADDomainController/en-US/MSFT_xADDomainController.strings.psd1
@@ -14,10 +14,10 @@ ConvertFrom-StringData @'
     FailedToFindSite              = The site '{0}' could not be found in the domain '{1}'. (ADDC0014)
     TestingConfiguration          = Determine the state of the domain controller on the current node '{0}' in the domain '{1}'. (ADDC0015)
     WrongSite                     = The domain controller is in the site '{0}', but expected it to be in the site '{1}'. (ADDC0016)
-    ExpectedDomainController      = Expected the node to be a domain controller, but did not get a domain controller object. (ADDC0017)
     ExpectedGlobalCatalogEnabled  = The domain controller does not contain a Global Catalog, but it was expected to have a Global Catalog. (ADDC0018)
     ExpectedGlobalCatalogDisabled = The domain controller have a Global Catalog, but it was expected to not have a Global Catalog. (ADDC0019)
     AllowedSyncAccountsMismatch   = There is a mismatch in AllowPasswordReplicationAccountName list. Got {0}, expected was {1}. (ADDC0020)
     DenySyncAccountsMismatch      = There is a mismatch in DenyPasswordReplicationAccountName list. Got {0}, expected was {1}. (ADDC0021)
     RODCMissingSite               = You have specified 'ReadOnlyReplica', but did not provide a site name. (ADDC0022)
+    CannotConvertToRODC           = Cannot convert a existing domain controller to a Read-Only Domain Controller (RODC). (ADDC0023)
 '@

--- a/DSCResources/MSFT_xADDomainController/en-US/MSFT_xADDomainController.strings.psd1
+++ b/DSCResources/MSFT_xADDomainController/en-US/MSFT_xADDomainController.strings.psd1
@@ -17,4 +17,7 @@ ConvertFrom-StringData @'
     ExpectedDomainController      = Expected the node to be a domain controller, but did not get a domain controller object. (ADDC0017)
     ExpectedGlobalCatalogEnabled  = The domain controller does not contain a Global Catalog, but it was expected to have a Global Catalog. (ADDC0018)
     ExpectedGlobalCatalogDisabled = The domain controller have a Global Catalog, but it was expected to not have a Global Catalog. (ADDC0019)
+    AllowedSyncAccountsMismatch   = There is a mismatch in AllowPasswordReplicationAccountName list. Got {0}, expected was {1}. (ADDC0020)
+    DenySyncAccountsMismatch      = There is a mismatch in DenyPasswordReplicationAccountName list. Got {0}, expected was {1}. (ADDC0021)
+    RODCMissingSite               = You have specified 'ReadonlyReplica', but did not provide a site name. (ADDC0022)
 '@

--- a/DSCResources/MSFT_xADDomainController/en-US/about_xADDomainController.help.txt
+++ b/DSCResources/MSFT_xADDomainController/en-US/about_xADDomainController.help.txt
@@ -3,7 +3,8 @@
 
 .DESCRIPTION
     The xADDomainController DSC resource will install and configure domain
-    controllers in Active Directory.
+    controllers in Active Directory. Installation of Read-Only Domain Controllers
+    (RODC) is also supported.
 
     >**Note:** If the account used for the parameter `DomainAdministratorCredential`
     >cannot connect to another domain controller, for example using a credential
@@ -56,6 +57,18 @@
 .PARAMETER Ensure
     Read - String
     Returns the state of the Domain Controller.
+
+.PARAMETER ReadOnlyReplica
+    Write - Boolean
+    Indicates that the cmdlet installs the domain controller as an Read-Only Domain Controller (RODC) for an existing domain.
+
+.PARAMETER AllowPasswordReplicationAccountName
+    Write - String
+    Specifies an array of names of user accounts, group accounts, and computer accounts whose passwords can be replicated to this Read-Only Domain Controller (RODC).
+
+.PARAMETER DenyPasswordReplicationAccountName
+    Write - String
+    Specifies the names of user accounts, group accounts, and computer accounts whose passwords are not to be replicated to this Read-Only Domain Controller (RODC).
 
 .EXAMPLE 1
 
@@ -224,6 +237,65 @@ Configuration AddDomainControllerToDomainUsingIFM_Config
             InstallationMediaPath         = 'F:\IFM'
 
             DependsOn                     = '[xWaitForADDomain]WaitForestAvailability'
+        }
+    }
+}
+
+.EXAMPLE 4
+
+This configuration will add a read-only domain controller to the domain contoso.com
+and specify a list of account, whose passwords are allowed/denied for synchronisation.
+
+Configuration AddReadOnlyDomainController_Config
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.PSCredential]
+        $DomainAdministratorCredential
+    )
+
+    Import-DscResource -ModuleName PSDscResources
+    Import-DscResource -ModuleName xActiveDirectory
+
+    node localhost
+    {
+        WindowsFeature 'InstallADDomainServicesFeature'
+        {
+            Ensure = 'Present'
+            Name   = 'AD-Domain-Services'
+        }
+
+        WindowsFeature 'RSATADPowerShell'
+        {
+            Ensure    = 'Present'
+            Name      = 'RSAT-AD-PowerShell'
+
+            DependsOn = '[WindowsFeature]InstallADDomainServicesFeature'
+        }
+
+        xWaitForADDomain 'WaitForestAvailability'
+        {
+            DomainName           = 'contoso.com'
+            DomainUserCredential = $DomainAdministratorCredential
+            RetryCount           = 10
+            RetryIntervalSec     = 120
+
+            DependsOn            = '[WindowsFeature]RSATADPowerShell'
+        }
+
+        xADDomainController 'Read-OnlyDomainController(RODC)'
+        {
+            DomainName                          = 'contoso.com'
+            DomainAdministratorCredential       = $DomainAdministratorCredential
+            SafemodeAdministratorPassword       = $DomainAdministratorCredential
+            ReadOnlyReplica                     = $true
+            SiteName                            = 'Default-First-Site-Name'
+            AllowPasswordReplicationAccountName = @('pvdi.test1', 'pvdi.test')
+            DenyPasswordReplicationAccountName  = @('SVC_PVS', 'TA2SCVMM')
+
+            DependsOn                           = '[xWaitForADDomain]WaitForestAvailability'
         }
     }
 }

--- a/Examples/Resources/xADDomainController/4-AddReadOnlyDomainController_Config.ps1
+++ b/Examples/Resources/xADDomainController/4-AddReadOnlyDomainController_Config.ps1
@@ -16,13 +16,13 @@
 #>
 
 #Requires -module xActiveDirectory
+
 <#
     .DESCRIPTION
     This configuration will add a read-only domain controller to the domain contoso.com
     and specify a list of account, whose passwords are allowed/denied for synchronisation.
 #>
-
-Configuration Read-OnlyDomainController_Config
+Configuration AddReadOnlyDomainController_Config
 {
     param
     (
@@ -68,8 +68,9 @@ Configuration Read-OnlyDomainController_Config
             SafemodeAdministratorPassword       = $DomainAdministratorCredential
             ReadOnlyReplica                     = $true
             SiteName                            = 'Default-First-Site-Name'
-            AllowPasswordReplicationAccountName = 'pvdi.test1', 'pvdi.test'
-            DenyPasswordReplicationAccountName  = 'SVC_PVS', 'TA2SCVMM'
+            AllowPasswordReplicationAccountName = @('pvdi.test1', 'pvdi.test')
+            DenyPasswordReplicationAccountName  = @('SVC_PVS', 'TA2SCVMM')
+
             DependsOn                           = '[xWaitForADDomain]WaitForestAvailability'
         }
     }

--- a/Examples/Resources/xADDomainController/4-Read-OnlyDomainController_Config.ps1
+++ b/Examples/Resources/xADDomainController/4-Read-OnlyDomainController_Config.ps1
@@ -1,0 +1,76 @@
+<#PSScriptInfo
+.VERSION 1.0.0
+.GUID ba30df50-0873-4c2c-872b-96f5c825910d
+.AUTHOR Microsoft Corporation
+.COMPANYNAME Microsoft Corporation
+.COPYRIGHT (c) Microsoft Corporation. All rights reserved.
+.TAGS DSCConfiguration
+.LICENSEURI https://github.com/PowerShell/xActiveDirectory/blob/master/LICENSE
+.PROJECTURI https://github.com/PowerShell/xActiveDirectory
+.ICONURI
+.EXTERNALMODULEDEPENDENCIES
+.REQUIREDSCRIPTS
+.EXTERNALSCRIPTDEPENDENCIES
+.RELEASENOTES First version.
+.PRIVATEDATA 2016-Datacenter,2016-Datacenter-Server-Core
+#>
+
+#Requires -module xActiveDirectory
+<#
+    .DESCRIPTION
+    This configuration will add a read-only domain controller to the domain contoso.com
+    and specify a list of account, whose passwords are allowed/denied for synchronisation.
+#>
+
+Configuration Read-OnlyDomainController_Config
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.PSCredential]
+        $DomainAdministratorCredential
+    )
+
+    Import-DscResource -ModuleName PSDscResources
+    Import-DscResource -ModuleName xActiveDirectory
+
+    node localhost
+    {
+        WindowsFeature 'InstallADDomainServicesFeature'
+        {
+            Ensure = 'Present'
+            Name   = 'AD-Domain-Services'
+        }
+
+        WindowsFeature 'RSATADPowerShell'
+        {
+            Ensure    = 'Present'
+            Name      = 'RSAT-AD-PowerShell'
+
+            DependsOn = '[WindowsFeature]InstallADDomainServicesFeature'
+        }
+
+        xWaitForADDomain 'WaitForestAvailability'
+        {
+            DomainName           = 'contoso.com'
+            DomainUserCredential = $DomainAdministratorCredential
+            RetryCount           = 10
+            RetryIntervalSec     = 120
+
+            DependsOn            = '[WindowsFeature]RSATADPowerShell'
+        }
+
+        xADDomainController 'Read-OnlyDomainController(RODC)'
+        {
+            DomainName                          = 'contoso.com'
+            DomainAdministratorCredential       = $DomainAdministratorCredential
+            SafemodeAdministratorPassword       = $DomainAdministratorCredential
+            ReadOnlyReplica                     = $true
+            SiteName                            = 'Default-First-Site-Name'
+            AllowPasswordReplicationAccountName = 'pvdi.test1', 'pvdi.test'
+            DenyPasswordReplicationAccountName  = 'SVC_PVS', 'TA2SCVMM'
+            DependsOn                           = '[xWaitForADDomain]WaitForestAvailability'
+        }
+    }
+}

--- a/Tests/Unit/MSFT_xADDomainController.Tests.ps1
+++ b/Tests/Unit/MSFT_xADDomainController.Tests.ps1
@@ -1023,7 +1023,7 @@ try
                             $result = Get-MembersToAddAndRemove -DesiredMembers 'Member1' -CurrentMembers $null
                             $result.MembersToAdd | Should -HaveCount 1
                             $result.MembersToAdd[0].ToString() | Should -Be 'Member1'
-                            $result.MembersToRemove | Should -HaveCount 0
+                            $result.MembersToRemove | Should -BeNullOrEmpty
                         }
                     }
 
@@ -1032,7 +1032,7 @@ try
                             $result = Get-MembersToAddAndRemove -DesiredMembers 'Member1' -CurrentMembers @()
                             $result.MembersToAdd | Should -HaveCount 1
                             $result.MembersToAdd[0].ToString() | Should -Be 'Member1'
-                            $result.MembersToRemove | Should -HaveCount 0
+                            $result.MembersToRemove | Should -BeNullOrEmpty
                         }
                     }
                 }
@@ -1074,16 +1074,16 @@ try
                     Context 'When proving a $null value for DesiredMembers and CurrentMembers' {
                         It 'Should return the correct values' {
                             $result = Get-MembersToAddAndRemove -DesiredMembers $null -CurrentMembers $null
-                            $result.MembersToAdd | Should -HaveCount 0
-                            $result.MembersToRemove | Should -HaveCount 0
+                            $result.MembersToAdd | Should -BeNullOrEmpty
+                            $result.MembersToRemove | Should -BeNullOrEmpty
                         }
                     }
 
                     Context 'When proving an empty collection for DesiredMembers and CurrentMembers' {
                         It 'Should return the correct values' {
                             $result = Get-MembersToAddAndRemove -DesiredMembers @() -CurrentMembers @()
-                            $result.MembersToAdd | Should -HaveCount 0
-                            $result.MembersToRemove | Should -HaveCount 0
+                            $result.MembersToAdd | Should -BeNullOrEmpty
+                            $result.MembersToRemove | Should -BeNullOrEmpty
                         }
                     }
                 }
@@ -1092,14 +1092,14 @@ try
                     It 'Should return the correct values' {
                         Context 'When proving a collection for CurrentMembers' {
                             $result = Get-MembersToAddAndRemove -DesiredMembers $null -CurrentMembers @('OldMember')
-                            $result.MembersToAdd | Should -HaveCount 0
+                            $result.MembersToAdd | Should -BeNullOrEmpty
                             $result.MembersToRemove | Should -HaveCount 1
                             $result.MembersToRemove[0].ToString() | Should -Be 'OldMember'
                         }
 
                         Context 'When proving a string value for CurrentMembers' {
                             $result = Get-MembersToAddAndRemove -DesiredMembers $null -CurrentMembers 'OldMember'
-                            $result.MembersToAdd | Should -HaveCount 0
+                            $result.MembersToAdd | Should -BeNullOrEmpty
                             $result.MembersToRemove | Should -HaveCount 1
                             $result.MembersToRemove[0].ToString() | Should -Be 'OldMember'
                         }
@@ -1109,7 +1109,7 @@ try
                 Context 'When there more than one current member' {
                     It 'Should return the correct values' {
                         $result = Get-MembersToAddAndRemove -DesiredMembers $null -CurrentMembers @('OldMember1','OldMember2')
-                        $result.MembersToAdd | Should -HaveCount 0
+                        $result.MembersToAdd | Should -BeNullOrEmpty
                         $result.MembersToRemove | Should -HaveCount 2
                         $result.MembersToRemove[0].ToString() | Should -Be 'OldMember1'
                         $result.MembersToRemove[1].ToString() | Should -Be 'OldMember2'
@@ -1120,14 +1120,14 @@ try
             Context 'When the same members are present in desired members and current members' {
                 Context 'When proving a collection for CurrentMembers' {
                     $result = Get-MembersToAddAndRemove -DesiredMembers @('Member1') -CurrentMembers @('Member1')
-                    $result.MembersToAdd | Should -HaveCount 0
-                    $result.MembersToRemove | Should -HaveCount 0
+                    $result.MembersToAdd | Should -BeNullOrEmpty
+                    $result.MembersToRemove | Should -BeNullOrEmpty
                 }
 
                 Context 'When proving a string value for CurrentMembers' {
                     $result = Get-MembersToAddAndRemove -DesiredMembers 'Member1' -CurrentMembers 'Member1'
-                    $result.MembersToAdd | Should -HaveCount 0
-                    $result.MembersToRemove | Should -HaveCount 0
+                    $result.MembersToAdd | Should -BeNullOrEmpty
+                    $result.MembersToRemove | Should -BeNullOrEmpty
                 }
             }
 
@@ -1136,14 +1136,14 @@ try
                     $result = Get-MembersToAddAndRemove -DesiredMembers @('Member1','Member2') -CurrentMembers @('Member1')
                     $result.MembersToAdd | Should -HaveCount 1
                     $result.MembersToAdd[0].ToString() | Should -Be 'Member2'
-                    $result.MembersToRemove | Should -HaveCount 0
+                    $result.MembersToRemove | Should -BeNullOrEmpty
                 }
             }
 
             Context 'When the there are fewer desired members than current members' {
                 Context 'When proving a string value for CurrentMembers' {
                     $result = Get-MembersToAddAndRemove -DesiredMembers 'Member1' -CurrentMembers @('Member1','Member2')
-                    $result.MembersToAdd | Should -HaveCount 0
+                    $result.MembersToAdd | Should -BeNullOrEmpty
                     $result.MembersToRemove | Should -HaveCount 1
                     $result.MembersToRemove[0].ToString() | Should -Be 'Member2'
                 }

--- a/Tests/Unit/MSFT_xADDomainController.Tests.ps1
+++ b/Tests/Unit/MSFT_xADDomainController.Tests.ps1
@@ -230,10 +230,6 @@ try
         #region Function Test-TargetResource
         Describe 'xActiveDirectory\Test-TargetResource' -Tag 'Test' {
             BeforeAll {
-                $stubDomainController = New-Object -TypeName Microsoft.ActiveDirectory.Management.ADDomainController
-                $stubDomainController.Site = $correctSiteName
-
-                Mock -CommandName Get-DomainControllerObject -MockWith { return $stubDomainController }
                 Mock -CommandName Get-ADDomainControllerPasswordReplicationPolicy -ParameterFilter { $Allowed.IsPresent } -MockWith {
                     return [PSCustomObject]@{
                         SamAccountName = $allowedAccount
@@ -304,7 +300,7 @@ try
                 $stubDomainController = New-Object -TypeName Microsoft.ActiveDirectory.Management.ADDomainController
                 $stubDomainController.Site = $correctSiteName
                 $stubDomainController.Domain = $correctDomainName
-                $stubDomainController.IsGlobalCatalog = $false
+                Add-Member -InputObject $stubDomainController -name 'IsGlobalCatalog' -Value $false -MemberType NoteProperty -Force
 
                 Mock -CommandName Get-ADDomain -MockWith { return $true }
                 Mock -CommandName Get-DomainControllerObject -MockWith { return $stubDomainController }
@@ -324,7 +320,7 @@ try
                 $stubDomainController = New-Object -TypeName Microsoft.ActiveDirectory.Management.ADDomainController
                 $stubDomainController.Site = $correctSiteName
                 $stubDomainController.Domain = $correctDomainName
-                $stubDomainController.IsGlobalCatalog = $true
+                Add-Member -InputObject $stubDomainController -name 'IsGlobalCatalog' -Value $true -MemberType NoteProperty -Force
 
                 Mock -CommandName Get-ADDomain -MockWith { return $true }
                 Mock -CommandName Get-DomainControllerObject -MockWith { return $stubDomainController }
@@ -343,6 +339,10 @@ try
             }
 
             It 'Returns "True" when AllowPasswordReplicationAccountName matches' {
+                $stubDomainController = New-Object -TypeName Microsoft.ActiveDirectory.Management.ADDomainController
+                $stubDomainController.Site = $correctSiteName
+
+                Mock -CommandName Get-DomainControllerObject -MockWith { return $stubDomainController }
                 Mock -CommandName Get-ADDomainControllerPasswordReplicationPolicy -ParameterFilter { $Allowed.IsPresent } -MockWith {
                     return @(
                         [PSCustomObject]@{
@@ -411,6 +411,10 @@ try
             }
 
             It 'Returns "True" when DenyPasswordReplicationAccountName matches' {
+                $stubDomainController = New-Object -TypeName Microsoft.ActiveDirectory.Management.ADDomainController
+                $stubDomainController.Site = $correctSiteName
+
+                Mock -CommandName Get-DomainControllerObject -MockWith { return $stubDomainController }
                 Mock -CommandName Get-ADDomainControllerPasswordReplicationPolicy -ParameterFilter { $Denied.IsPresent } -MockWith {
                     return @(
                         [PSCustomObject]@{

--- a/Tests/Unit/MSFT_xADDomainController.Tests.ps1
+++ b/Tests/Unit/MSFT_xADDomainController.Tests.ps1
@@ -262,7 +262,6 @@ try
                 $result | Should -Be $false
             }
 
-
             It 'Returns "True" when "SiteName" matches' {
                 $stubDomainController = New-Object -TypeName Microsoft.ActiveDirectory.Management.ADDomainController
                 $stubDomainController.Site = $correctSiteName
@@ -571,7 +570,7 @@ try
                     It 'Throws the correct exception' {
                         {
                             Set-TargetResource @testDefaultParams -DomainName $correctDomainName -ReadOnlyReplica $true
-                        } | Should -Throw ($script:localizedData.RODCMissingSite)
+                        } | Should -Throw $script:localizedData.RODCMissingSite
                     }
                 }
 

--- a/Tests/Unit/MSFT_xADDomainController.Tests.ps1
+++ b/Tests/Unit/MSFT_xADDomainController.Tests.ps1
@@ -589,6 +589,26 @@ try
                         Assert-MockCalled -CommandName Get-TargetResource -Exactly -Times 0 -Scope It
                     }
                 }
+
+                Context 'When providing parameter ReadOnlyReplica with a value of $true, but the node is already a writeable Domain Controller' {
+                    BeforeAll {
+                        Mock -CommandName Get-TargetResource -MockWith {
+                            return @{
+                                DomainName                          = $correctDomainName
+                                ReadOnlyReplica                     = $false
+                                Ensure                              = $true
+                            }
+                        }
+                    }
+
+                    It 'Should throw the correct error' {
+                        {
+                            Test-TargetResource @testDefaultParams -DomainName $correctDomainName -SiteName $correctSiteName -ReadOnlyReplica $true
+                        } | Should -Throw $script:localizedData.CannotConvertToRODC
+
+                        Assert-MockCalled -CommandName Get-TargetResource -Exactly -Times 1 -Scope It
+                    }
+                }
             }
         }
         #endregion

--- a/Tests/Unit/MSFT_xADDomainController.Tests.ps1
+++ b/Tests/Unit/MSFT_xADDomainController.Tests.ps1
@@ -1022,7 +1022,7 @@ try
                         It 'Should return the correct values' {
                             $result = Get-MembersToAddAndRemove -DesiredMembers 'Member1' -CurrentMembers $null
                             $result.MembersToAdd | Should -HaveCount 1
-                            $result.MembersToAdd[0].SamAccountName | Should -Be 'Member1'
+                            $result.MembersToAdd[0].ToString() | Should -Be 'Member1'
                             $result.MembersToRemove | Should -HaveCount 0
                         }
                     }
@@ -1031,7 +1031,7 @@ try
                         It 'Should return the correct values' {
                             $result = Get-MembersToAddAndRemove -DesiredMembers 'Member1' -CurrentMembers @()
                             $result.MembersToAdd | Should -HaveCount 1
-                            $result.MembersToAdd[0].SamAccountName | Should -Be 'Member1'
+                            $result.MembersToAdd[0].ToString() | Should -Be 'Member1'
                             $result.MembersToRemove | Should -HaveCount 0
                         }
                     }
@@ -1042,17 +1042,17 @@ try
                         Context 'When proving a collection for CurrentMembers' {
                             $result = Get-MembersToAddAndRemove -DesiredMembers 'Member1' -CurrentMembers @('OldMember')
                             $result.MembersToAdd | Should -HaveCount 1
-                            $result.MembersToAdd[0].SamAccountName | Should -Be 'Member1'
+                            $result.MembersToAdd[0].ToString() | Should -Be 'Member1'
                             $result.MembersToRemove | Should -HaveCount 1
-                            $result.MembersToRemove[0].SamAccountName | Should -Be 'OldMember'
+                            $result.MembersToRemove[0].ToString() | Should -Be 'OldMember'
                         }
 
                         Context 'When proving a string value for CurrentMembers' {
                             $result = Get-MembersToAddAndRemove -DesiredMembers 'Member1' -CurrentMembers 'OldMember'
                             $result.MembersToAdd | Should -HaveCount 1
-                            $result.MembersToAdd[0].SamAccountName | Should -Be 'Member1'
+                            $result.MembersToAdd[0].ToString() | Should -Be 'Member1'
                             $result.MembersToRemove | Should -HaveCount 1
-                            $result.MembersToRemove[0].SamAccountName | Should -Be 'OldMember'
+                            $result.MembersToRemove[0].ToString() | Should -Be 'OldMember'
                         }
                     }
                 }
@@ -1061,10 +1061,10 @@ try
                     It 'Should return the correct values' {
                         $result = Get-MembersToAddAndRemove -DesiredMembers 'Member1' -CurrentMembers @('OldMember1','OldMember2')
                         $result.MembersToAdd | Should -HaveCount 1
-                        $result.MembersToAdd[0].SamAccountName | Should -Be 'Member1'
+                        $result.MembersToAdd[0].ToString() | Should -Be 'Member1'
                         $result.MembersToRemove | Should -HaveCount 2
-                        $result.MembersToRemove[0].SamAccountName | Should -Be 'OldMember1'
-                        $result.MembersToRemove[1].SamAccountName | Should -Be 'OldMember2'
+                        $result.MembersToRemove[0].ToString() | Should -Be 'OldMember1'
+                        $result.MembersToRemove[1].ToString() | Should -Be 'OldMember2'
                     }
                 }
             }
@@ -1094,14 +1094,14 @@ try
                             $result = Get-MembersToAddAndRemove -DesiredMembers $null -CurrentMembers @('OldMember')
                             $result.MembersToAdd | Should -HaveCount 0
                             $result.MembersToRemove | Should -HaveCount 1
-                            $result.MembersToRemove[0].SamAccountName | Should -Be 'OldMember'
+                            $result.MembersToRemove[0].ToString() | Should -Be 'OldMember'
                         }
 
                         Context 'When proving a string value for CurrentMembers' {
                             $result = Get-MembersToAddAndRemove -DesiredMembers $null -CurrentMembers 'OldMember'
                             $result.MembersToAdd | Should -HaveCount 0
                             $result.MembersToRemove | Should -HaveCount 1
-                            $result.MembersToRemove[0].SamAccountName | Should -Be 'OldMember'
+                            $result.MembersToRemove[0].ToString() | Should -Be 'OldMember'
                         }
                     }
                 }
@@ -1111,8 +1111,8 @@ try
                         $result = Get-MembersToAddAndRemove -DesiredMembers $null -CurrentMembers @('OldMember1','OldMember2')
                         $result.MembersToAdd | Should -HaveCount 0
                         $result.MembersToRemove | Should -HaveCount 2
-                        $result.MembersToRemove[0].SamAccountName | Should -Be 'OldMember1'
-                        $result.MembersToRemove[1].SamAccountName | Should -Be 'OldMember2'
+                        $result.MembersToRemove[0].ToString() | Should -Be 'OldMember1'
+                        $result.MembersToRemove[1].ToString() | Should -Be 'OldMember2'
                     }
                 }
             }
@@ -1135,7 +1135,7 @@ try
                 Context 'When proving a collection for CurrentMembers' {
                     $result = Get-MembersToAddAndRemove -DesiredMembers @('Member1','Member2') -CurrentMembers @('Member1')
                     $result.MembersToAdd | Should -HaveCount 1
-                    $result.MembersToAdd[0].SamAccountName | Should -Be 'Member2'
+                    $result.MembersToAdd[0].ToString() | Should -Be 'Member2'
                     $result.MembersToRemove | Should -HaveCount 0
                 }
             }
@@ -1145,7 +1145,7 @@ try
                     $result = Get-MembersToAddAndRemove -DesiredMembers 'Member1' -CurrentMembers @('Member1','Member2')
                     $result.MembersToAdd | Should -HaveCount 0
                     $result.MembersToRemove | Should -HaveCount 1
-                    $result.MembersToRemove[0].SamAccountName | Should -Be 'Member2'
+                    $result.MembersToRemove[0].ToString() | Should -Be 'Member2'
                 }
             }
         }

--- a/Tests/Unit/MSFT_xADDomainController.Tests.ps1
+++ b/Tests/Unit/MSFT_xADDomainController.Tests.ps1
@@ -256,7 +256,6 @@ try
                 $stubDomainController.Site = $incorrectSiteName
                 $stubDomainController.Domain = $correctDomainName
 
-
                 Mock -CommandName Get-ADDomain -MockWith { return $true }
                 Mock -CommandName Get-DomainControllerObject -MockWith { return $stubDomainController }
                 Mock -CommandName Test-ADReplicationSite -MockWith { return $true }
@@ -287,7 +286,6 @@ try
                 $stubDomainController = New-Object -TypeName Microsoft.ActiveDirectory.Management.ADDomainController
                 $stubDomainController.Site = $correctSiteName
                 $stubDomainController.Domain = $correctDomainName
-
 
                 Mock -CommandName Get-ADDomain -MockWith { return $true }
                 Mock -CommandName Get-DomainControllerObject -MockWith { return $stubDomainController }
@@ -326,7 +324,7 @@ try
                 $stubDomainController = New-Object -TypeName Microsoft.ActiveDirectory.Management.ADDomainController
                 $stubDomainController.Site = $correctSiteName
                 $stubDomainController.Domain = $correctDomainName
-                Add-Member -InputObject $stubDomainController -name 'IsGlobalCatalog' -Value $true -MemberType NoteProperty -Force
+                $stubDomainController.IsGlobalCatalog = $true
 
                 Mock -CommandName Get-ADDomain -MockWith { return $true }
                 Mock -CommandName Get-DomainControllerObject -MockWith { return $stubDomainController }
@@ -341,7 +339,7 @@ try
             It 'Throws if "ReadOnlyReplica" is specified without Site' {
                 {
                     Test-TargetResource @testDefaultParams -DomainName $correctDomainName -ReadOnlyReplica $true
-                } | Should -Throw ($script:localizedData.RODCMissingSite)
+                } | Should -Throw $script:localizedData.RODCMissingSite
             }
 
             It 'Returns "True" when AllowPasswordReplicationAccountName matches' {
@@ -602,7 +600,11 @@ try
                                 SiteName = 'IncorrectSite'
                             }
                         }
-                        #Without this line the local tests are crashing powershell.exe (both 5 and 6). See line 606
+
+                        <#
+                            Without this line the local tests are crashing powershell.exe (both 5 and 6).
+                            See test 'Should call the correct mocks to move the domain controller to the correct site'.
+                        #>
                         Mock -CommandName Get-DomainControllerObject -MockWith {
                             return (New-Object -TypeName Microsoft.ActiveDirectory.Management.ADDomainController)
                         }
@@ -611,7 +613,6 @@ try
                     It 'Should call the correct mocks to move the domain controller to the correct site' {
                         { Set-TargetResource @testDefaultParams -DomainName $correctDomainName -SiteName $correctSiteName } | Should -Not -Throw
 
-                        # FYI: This test will fail when run locally, but should succeed on the build server
                         Assert-MockCalled -CommandName Move-ADDirectoryServer -ParameterFilter {
                             $Site.ToString() -eq $correctSiteName
                         } -Exactly -Times 1 -Scope It

--- a/Tests/Unit/Stubs/ActiveDirectoryStub.psm1
+++ b/Tests/Unit/Stubs/ActiveDirectoryStub.psm1
@@ -104,7 +104,7 @@ function Add-ADComputerServiceAccount
 #>
 function Add-ADDomainControllerPasswordReplicationPolicy
 {
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess = $true)]
     param
     (
         [Parameter(Mandatory = $true, ParameterSetName = 'AllowedPRP')]
@@ -5135,7 +5135,7 @@ function Remove-ADComputerServiceAccount
 #>
 function Remove-ADDomainControllerPasswordReplicationPolicy
 {
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess = $true)]
     param
     (
         [Parameter(Mandatory = $true, ParameterSetName = 'AllowedPRP')]

--- a/Tests/Unit/Stubs/Microsoft.ActiveDirectory.Management.cs
+++ b/Tests/Unit/Stubs/Microsoft.ActiveDirectory.Management.cs
@@ -108,6 +108,20 @@ namespace Microsoft.ActiveDirectory.Management
     {
         string site;
         public ADReplicationSite(System.String s){ site = s; }
+
+        // Added so that MSFT_xADDomainController unit test works
+        // 'When a domain controller is in the wrong site'
+        //     'Should call the correct mocks to move the domain controller to the correct site'
+
+        // The cmdlet Move-ADDirectoryServer accepts a string for the parameter
+        // Site, but that string get converted to a ADReplicationSite object.
+        // The ADReplicationSite object is what Pester sees and this method is
+        // the only one exposed in the real ADReplicationSite object to return
+        // the site name.
+        public override string ToString()
+        {
+            return this.site;
+        }
     }
 }
 

--- a/Tests/Unit/Stubs/Microsoft.ActiveDirectory.Management.cs
+++ b/Tests/Unit/Stubs/Microsoft.ActiveDirectory.Management.cs
@@ -103,6 +103,11 @@ namespace Microsoft.ActiveDirectory.Management
         public ADPrincipal():base(){}
         public ADPrincipal(System.String Identity):base(){ SamAccountName = Identity; }
         public string SamAccountName { get; set; }
+
+        public override string ToString()
+        {
+            return this.SamAccountName;
+        }
     }
 
     public class ADReplicationSite

--- a/Tests/Unit/Stubs/Microsoft.ActiveDirectory.Management.cs
+++ b/Tests/Unit/Stubs/Microsoft.ActiveDirectory.Management.cs
@@ -78,6 +78,7 @@ namespace Microsoft.ActiveDirectory.Management
         public string Site;
         public string Domain;
         public bool IsGlobalCatalog;
+        public bool IsReadOnly;
     }
 
     public class ADDirectoryServer

--- a/Tests/Unit/Stubs/Microsoft.ActiveDirectory.Management.cs
+++ b/Tests/Unit/Stubs/Microsoft.ActiveDirectory.Management.cs
@@ -75,6 +75,9 @@ namespace Microsoft.ActiveDirectory.Management
     {
         public ADDomainController():base(){}
         public ADDomainController(System.String Identity):base(){}
+        public string Site;
+        public string Domain;
+        public bool IsGlobalCatalog;
     }
 
     public class ADDirectoryServer
@@ -97,7 +100,8 @@ namespace Microsoft.ActiveDirectory.Management
     public class ADPrincipal
     {
         public ADPrincipal():base(){}
-        public ADPrincipal(System.String Identity):base(){}
+        public ADPrincipal(System.String Identity):base(){ SamAccountName = Identity; }
+        public string SamAccountName { get; set; }
     }
 
     public class ADReplicationSite


### PR DESCRIPTION
#### Pull Request (PR) description

Adding support for Read-only Domain Controllers creation.

#### This Pull Request (PR) fixes the following issues

- Fixes #40
- Replaces PR #390 

#### Task list

- [x] Added an entry under the Unreleased section in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [x] Resource documentation added/updated in resource directory README.md.
- [x] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xactivedirectory/406)
<!-- Reviewable:end -->
