### PR TITLE
xADUser: Fix CN/Path Concurrent Change and Empty String Property on Creation Exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   - Added 'about_\<DSCResource\>.help.txt' file to all resources ([issue #404](https://github.com/PowerShell/xActiveDirectory/pull/404)).
 - Changes to xADManagedServiceAccount
   - Added a requirement to README stating "Group Managed Service Accounts need at least one Windows Server 2012 Domain Controller" ([issue #399](https://github.com/PowerShell/xActiveDirectory/pull/399)).
+- Changes to xADUser
+  - Fixes exception when creating a user with an empty string property ([issue #407](https://github.com/PowerShell/xActiveDirectory/pull/407)).
+  - Fixes exception when updating `CommonName` and `Path` concurrently ([issue #402](https://github.com/PowerShell/xActiveDirectory/pull/402)).
 
 ## 3.0.0.0
 

--- a/DSCResources/MSFT_xADUser/MSFT_xADUser.psm1
+++ b/DSCResources/MSFT_xADUser/MSFT_xADUser.psm1
@@ -1501,7 +1501,7 @@ function Set-TargetResource
                 if ($parameter -eq 'Path' -and ($PSBoundParameters.Path -ne $targetResource.Path))
                 {
                     # Move user after any property changes
-                    $moveUserRequired = $True
+                    $moveUserRequired = $true
                 }
                 elseif ($parameter -eq 'CommonName' -and ($PSBoundParameters.CommonName -ne $targetResource.CommonName))
                 {
@@ -1618,14 +1618,14 @@ function Set-TargetResource
         if ($moveUserRequired)
         {
             # Cannot move users by updating the DistinguishedName property
-            $adCommonParameters = Get-ADCommonParameters @PSBoundParameters
+            $moveAdObjectParameters = Get-ADCommonParameters @PSBoundParameters
 
             # Using the SamAccountName for identity with Move-ADObject does not work, use the DN instead
-            $adCommonParameters['Identity'] = $targetResource.DistinguishedName
+            $moveAdObjectParameters['Identity'] = $targetResource.DistinguishedName
 
             Write-Verbose -Message ($script:localizedData.MovingADUser -f $targetResource.Path, $PSBoundParameters.Path)
 
-            Move-ADObject @adCommonParameters -TargetPath $PSBoundParameters.Path
+            Move-ADObject @moveAdObjectParameters -TargetPath $PSBoundParameters.Path
 
             # Set new target resource DN in case a rename is also required
             $targetResource.DistinguishedName = "cn=$($targetResource.CommonName),$($PSBoundParameters.Path)"
@@ -1634,14 +1634,14 @@ function Set-TargetResource
         if ($renameUserRequired)
         {
             # Cannot rename users by updating the CN property directly
-            $adCommonParameters = Get-ADCommonParameters @PSBoundParameters
+            $renameAdObjectParameters = Get-ADCommonParameters @PSBoundParameters
 
             # Using the SamAccountName for identity with Rename-ADObject does not work, use the DN instead
-            $adCommonParameters['Identity'] = $targetResource.DistinguishedName
+            $renameAdObjectParameters['Identity'] = $targetResource.DistinguishedName
 
             Write-Verbose -Message ($script:localizedData.RenamingADUser -f $targetResource.CommonName, $PSBoundParameters.CommonName)
 
-            Rename-ADObject @adCommonParameters -NewName $PSBoundParameters.CommonName
+            Rename-ADObject @renameAdObjectParameters -NewName $PSBoundParameters.CommonName
         }
     }
     elseif (($Ensure -eq 'Absent') -and ($targetResource.Ensure -eq 'Present'))

--- a/DSCResources/MSFT_xADUser/MSFT_xADUser.psm1
+++ b/DSCResources/MSFT_xADUser/MSFT_xADUser.psm1
@@ -1064,6 +1064,7 @@ function Test-TargetResource
                 if (([System.String]::IsNullOrEmpty($PSBoundParameters.$parameter)) -and ([System.String]::IsNullOrEmpty($targetResource.$parameter)))
                 {
                     # Both values are null/empty and therefore we are compliant
+                    # Must catch this scenario separately, as Compare-Object can't compare Null objects
                 }
                 elseif (($null -ne $PSBoundParameters.$parameter -and $null -eq $targetResource.$parameter) -or
                         ($null -eq $PSBoundParameters.$parameter -and $null -ne $targetResource.$parameter) -or
@@ -1541,6 +1542,7 @@ function Set-TargetResource
                 elseif (([System.String]::IsNullOrEmpty($PSBoundParameters.$parameter)) -and ([System.String]::IsNullOrEmpty($targetResource.$parameter)))
                 {
                     # Both values are null/empty and therefore we are compliant
+                    # Must catch this scenario separately, as Compare-Object can't compare Null objects
                 }
                 # Use Compare-Object to allow comparison of string and array parameters
                 elseif (($null -ne $PSBoundParameters.$parameter -and $null -eq $targetResource.$parameter) -or

--- a/DSCResources/MSFT_xADUser/MSFT_xADUser.psm1
+++ b/DSCResources/MSFT_xADUser/MSFT_xADUser.psm1
@@ -1626,6 +1626,9 @@ function Set-TargetResource
             Write-Verbose -Message ($script:localizedData.MovingADUser -f $targetResource.Path, $PSBoundParameters.Path)
 
             Move-ADObject @adCommonParameters -TargetPath $PSBoundParameters.Path
+
+            # Set new target resource DN in case a rename is also required
+            $targetResource.DistinguishedName = "cn=$($targetResource.CommonName),$($PSBoundParameters.Path)"
         }
 
         if ($renameUserRequired)
@@ -1634,7 +1637,7 @@ function Set-TargetResource
             $adCommonParameters = Get-ADCommonParameters @PSBoundParameters
 
             # Using the SamAccountName for identity with Rename-ADObject does not work, use the DN instead
-            $adCommonParameters['Identity'] = "cn=$($targetResource.CommonName),$($PSBoundParameters.Path)"
+            $adCommonParameters['Identity'] = $targetResource.DistinguishedName
 
             Write-Verbose -Message ($script:localizedData.RenamingADUser -f $targetResource.CommonName, $PSBoundParameters.CommonName)
 

--- a/DSCResources/MSFT_xADUser/MSFT_xADUser.psm1
+++ b/DSCResources/MSFT_xADUser/MSFT_xADUser.psm1
@@ -1063,8 +1063,10 @@ function Test-TargetResource
                 # This check is required to be able to explicitly remove values with an empty string, if required
                 if (([System.String]::IsNullOrEmpty($PSBoundParameters.$parameter)) -and ([System.String]::IsNullOrEmpty($targetResource.$parameter)))
                 {
-                    # Both values are null/empty and therefore we are compliant
-                    # Must catch this scenario separately, as Compare-Object can't compare Null objects
+                    <#
+                        Both values are null/empty and therefore we are compliant
+                        Must catch this scenario separately, as Compare-Object can't compare Null objects
+                    #>
                 }
                 elseif (($null -ne $PSBoundParameters.$parameter -and $null -eq $targetResource.$parameter) -or
                         ($null -eq $PSBoundParameters.$parameter -and $null -ne $targetResource.$parameter) -or
@@ -1541,8 +1543,10 @@ function Set-TargetResource
                 }
                 elseif (([System.String]::IsNullOrEmpty($PSBoundParameters.$parameter)) -and ([System.String]::IsNullOrEmpty($targetResource.$parameter)))
                 {
-                    # Both values are null/empty and therefore we are compliant
-                    # Must catch this scenario separately, as Compare-Object can't compare Null objects
+                    <#
+                        Both values are null/empty and therefore we are compliant
+                        Must catch this scenario separately, as Compare-Object can't compare Null objects
+                    #>
                 }
                 # Use Compare-Object to allow comparison of string and array parameters
                 elseif (($null -ne $PSBoundParameters.$parameter -and $null -eq $targetResource.$parameter) -or

--- a/DSCResources/MSFT_xADUser/MSFT_xADUser.psm1
+++ b/DSCResources/MSFT_xADUser/MSFT_xADUser.psm1
@@ -1550,6 +1550,10 @@ function Set-TargetResource
                     #>
                     Write-Verbose -Message ($script:localizedData.UpdatingADUserProperty -f $parameter, $PSBoundParameters.$parameter)
                 }
+                elseif (([System.String]::IsNullOrEmpty($PSBoundParameters.$parameter)) -and ([System.String]::IsNullOrEmpty($targetResource.$parameter)))
+                {
+                    # Both values are null/empty and therefore we are compliant
+                }
                 # Use Compare-Object to allow comparison of string and array parameters
                 elseif (($null -ne $PSBoundParameters.$parameter -and $null -eq $targetResource.$parameter) -or
                         ($null -eq $PSBoundParameters.$parameter -and $null -ne $targetResource.$parameter) -or


### PR DESCRIPTION
#### Pull Request (PR) description

This PR makes the following changes to the `xADUser` resource:

- Adds an additional Null/Empty parameter & property check to prevent the exception when creating a User with an empty string property.
- Relocates the user move/rename code to after the `Set-ADUser` code and performs the `Move-ADObject` before the `Rename-ADObject` to prevent the exception when updating CommonName and Path at the same time.

#### This Pull Request (PR) fixes the following issues

- Fixes #402
- Fixes #407

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry under the Unreleased section in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in resource directory README.md.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xactivedirectory/412)
<!-- Reviewable:end -->
