### PR TITLE
xADOrganizationalUnit: Catch Exception When the Path Property specifies a Non-Existing Path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   - Added a requirement to README stating "Group Managed Service Accounts need at least one Windows Server 2012 Domain Controller" ([issue #399](https://github.com/PowerShell/xActiveDirectory/pull/399)).
 - Changes to xADComputer
   - Fixed the GUID in Example 3-AddComputerAccountSpecificPath_Config. ([issue #410](https://github.com/PowerShell/xActiveDirectory/pull/410))
+- Changes to xADOrganizationalUnit
+  - Catch exception when the path property specifies a non-existing path ([issue #408](https://github.com/PowerShell/xActiveDirectory/pull/408))
 
 ## 3.0.0.0
 

--- a/DSCResources/MSFT_xADOrganizationalUnit/MSFT_xADOrganizationalUnit.psm1
+++ b/DSCResources/MSFT_xADOrganizationalUnit/MSFT_xADOrganizationalUnit.psm1
@@ -23,7 +23,7 @@ function Get-TargetResource
 
     Assert-Module -ModuleName 'ActiveDirectory'
 
-    Write-Verbose ($script:localizedData.RetrievingOU -f $Name)
+    Write-Verbose ($script:localizedData.RetrievingOU -f $Name, $Path)
 
     try
     {

--- a/DSCResources/MSFT_xADOrganizationalUnit/MSFT_xADOrganizationalUnit.psm1
+++ b/DSCResources/MSFT_xADOrganizationalUnit/MSFT_xADOrganizationalUnit.psm1
@@ -25,7 +25,19 @@ function Get-TargetResource
 
     Write-Verbose ($script:localizedData.RetrievingOU -f $Name)
 
-    $ou = Get-ADOrganizationalUnit -Filter { Name -eq $Name } -SearchBase $Path -SearchScope OneLevel -Properties ProtectedFromAccidentalDeletion, Description
+    try
+    {
+        $ou = Get-ADOrganizationalUnit -Filter { Name -eq $Name } -SearchBase $Path -SearchScope OneLevel -Properties ProtectedFromAccidentalDeletion, Description
+    }
+    catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException]
+    {
+        $errorMessage = $script:localizedData.PathNotFoundError -f $Path
+        New-ObjectNotFoundException -Message $errorMessage
+    }
+    catch
+    {
+        throw $_
+    }
 
     if ($null -eq $ou)
     {

--- a/DSCResources/MSFT_xADOrganizationalUnit/en-US/MSFT_xADOrganizationalUnit.strings.psd1
+++ b/DSCResources/MSFT_xADOrganizationalUnit/en-US/MSFT_xADOrganizationalUnit.strings.psd1
@@ -1,6 +1,6 @@
 # culture="en-US"
 ConvertFrom-StringData @'
-    RetrievingOU               = Retrieving OU '{0}'.
+    RetrievingOU               = Retrieving OU '{0}' from path '{1}'.
     UpdatingOU                 = Updating OU '{0}'.
     DeletingOU                 = Deleting OU '{0}'.
     CreatingOU                 = Creating OU '{0}'.
@@ -10,4 +10,5 @@ ConvertFrom-StringData @'
     OUExistsButShouldNot       = OU '{0}' exists when it should not exist.
     OUDoesNotExistButShould    = OU '{0}' does not exist when it should exist.
     OUDoesNotExistAndShouldNot = OU '{0}' does not exist and is in the desired state.
+    PathNotFoundError          = The Path '{0}' was not found.
 '@

--- a/Tests/Unit/MSFT_xADOrganizationalUnit.Tests.ps1
+++ b/Tests/Unit/MSFT_xADOrganizationalUnit.Tests.ps1
@@ -154,6 +154,21 @@ try
                 $targetResource.Description | Should -BeNullOrEmpty
             }
 
+            It 'Should throw the correct error if the path does not exist' {
+                Mock -CommandName Assert-Module
+                Mock -CommandName Get-ADOrganizationalUnit -MockWith { throw New-Object Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException }
+
+                $errorMessage = $script:localizedData.PathNotFoundError -f $testPresentParams.Path
+                { Get-TargetResource -Name $testPresentParams.Name -Path $testPresentParams.Path } | Should -Throw $errorMessage
+            }
+
+            It 'Should throw the correct error if an unkwon error occurs' {
+                $error = 'Unknown Error'
+                Mock -CommandName Assert-Module
+                Mock -CommandName Get-ADOrganizationalUnit -MockWith { throw $error }
+
+                { Get-TargetResource -Name $testPresentParams.Name -Path $testPresentParams.Path } | Should -Throw $error
+            }
         }
         #endregion
 


### PR DESCRIPTION
#### Pull Request (PR) description

This PR adds code to the `xADOrganizationalUnit` resource to catch the `ADIdentityNotFoundException` returned by `Get-ADOrganizationalUnit` and return an improved error message.

#### This Pull Request (PR) fixes the following issues

- Fixes #408

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry under the Unreleased section in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in resource directory README.md.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xactivedirectory/413)
<!-- Reviewable:end -->
