### PR TITLE
xADUser: Fix ChangePasswordAtLogon Property to be only set to True at User Creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,17 +3,18 @@
 ## Unreleased
 
 - Changes to xActiveDirectory
-  - Added a Requirements section to every DSC resource README with the bullet point stating "Target machine must be running Windows Server 2008 R2 or later" ([issue #399](https://github.com/PowerShell/xActiveDirectory/pull/399)).
-  - Added 'about_\<DSCResource\>.help.txt' file to all resources ([issue #404](https://github.com/PowerShell/xActiveDirectory/pull/404)).
+  - Added a Requirements section to every DSC resource README with the bullet point stating "Target machine must be running Windows Server 2008 R2 or later" ([issue #399](https://github.com/PowerShell/xActiveDirectory/issues/399)).
+  - Added 'about_\<DSCResource\>.help.txt' file to all resources ([issue #404](https://github.com/PowerShell/xActiveDirectory/issues/404)).
 - Changes to xADManagedServiceAccount
-  - Added a requirement to README stating "Group Managed Service Accounts need at least one Windows Server 2012 Domain Controller" ([issue #399](https://github.com/PowerShell/xActiveDirectory/pull/399)).
+  - Added a requirement to README stating "Group Managed Service Accounts need at least one Windows Server 2012 Domain Controller" ([issue #399](https://github.com/PowerShell/xActiveDirectory/issues/399)).
 - Changes to xADComputer
-  - Fixed the GUID in Example 3-AddComputerAccountSpecificPath_Config. ([issue #410](https://github.com/PowerShell/xActiveDirectory/pull/410))
+  - Fixed the GUID in Example 3-AddComputerAccountSpecificPath_Config. ([issue #410](https://github.com/PowerShell/xActiveDirectory/issues/410)).
 - Changes to xADOrganizationalUnit
-  - Catch exception when the path property specifies a non-existing path ([issue #408](https://github.com/PowerShell/xActiveDirectory/pull/408))
+  - Catch exception when the path property specifies a non-existing path ([issue #408](https://github.com/PowerShell/xActiveDirectory/issues/408)).
 - Changes to xADUser
-  - Fixes exception when creating a user with an empty string property ([issue #407](https://github.com/PowerShell/xActiveDirectory/pull/407)).
-  - Fixes exception when updating `CommonName` and `Path` concurrently ([issue #402](https://github.com/PowerShell/xActiveDirectory/pull/402)).
+  - Fixes exception when creating a user with an empty string property ([issue #407](https://github.com/PowerShell/xActiveDirectory/issues/407)).
+  - Fixes exception when updating `CommonName` and `Path` concurrently ([issue #402](https://github.com/PowerShell/xActiveDirectory/issues/402)).
+  - Fixes ChangePasswordAtLogon Property to be only set to `true` at User Creation ([issue #414](https://github.com/PowerShell/xActiveDirectory/issues/414)).
 
 ## 3.0.0.0
 

--- a/DSCResources/MSFT_xADUser/MSFT_xADUser.psm1
+++ b/DSCResources/MSFT_xADUser/MSFT_xADUser.psm1
@@ -1455,7 +1455,7 @@ function Set-TargetResource
     # Add common name, ensure and enabled as they may not be explicitly passed
     $PSBoundParameters['Ensure'] = $Ensure
     $PSBoundParameters['Enabled'] = $Enabled
-    $newADUser = $false
+    $script:newADUser = $false
 
     if ($Ensure -eq 'Present')
     {
@@ -1492,7 +1492,7 @@ function Set-TargetResource
                 # Now retrieve the newly created user
                 $targetResource = Get-TargetResource @PSBoundParameters
 
-                $newADUser = $true
+                $script:newADUser = $true
             }
         }
 
@@ -1541,10 +1541,9 @@ function Set-TargetResource
                         Set-ADAccountPassword @adCommonParameters -Reset -NewPassword $Password.Password
                     }
                 }
-                elseif ($parameter -eq 'ChangePasswordAtLogon' -and $PSBoundParameters.$parameter -eq $true -and $newADUser -eq $false)
+                elseif ($parameter -eq 'ChangePasswordAtLogon' -and $PSBoundParameters.$parameter -eq $true -and $script:newADUser -eq $false)
                 {
                     # Only process the ChangePasswordAtLogon = $true parameter during new user creation
-                    Write-Verbose "Here"
                     continue
                 }
                 elseif ($parameter -eq 'Enabled' -and ($PSBoundParameters.$parameter -ne $targetResource.$parameter))

--- a/DSCResources/MSFT_xADUser/MSFT_xADUser.psm1
+++ b/DSCResources/MSFT_xADUser/MSFT_xADUser.psm1
@@ -1455,7 +1455,7 @@ function Set-TargetResource
     # Add common name, ensure and enabled as they may not be explicitly passed
     $PSBoundParameters['Ensure'] = $Ensure
     $PSBoundParameters['Enabled'] = $Enabled
-    $script:newADUser = $false
+    $newADUser = $false
 
     if ($Ensure -eq 'Present')
     {
@@ -1492,7 +1492,7 @@ function Set-TargetResource
                 # Now retrieve the newly created user
                 $targetResource = Get-TargetResource @PSBoundParameters
 
-                $script:newADUser = $true
+                $newADUser = $true
             }
         }
 
@@ -1541,7 +1541,7 @@ function Set-TargetResource
                         Set-ADAccountPassword @adCommonParameters -Reset -NewPassword $Password.Password
                     }
                 }
-                elseif ($parameter -eq 'ChangePasswordAtLogon' -and $PSBoundParameters.$parameter -eq $true -and $script:newADUser -eq $false)
+                elseif ($parameter -eq 'ChangePasswordAtLogon' -and $PSBoundParameters.$parameter -eq $true -and $newADUser -eq $false)
                 {
                     # Only process the ChangePasswordAtLogon = $true parameter during new user creation
                     continue

--- a/DSCResources/MSFT_xADUser/MSFT_xADUser.psm1
+++ b/DSCResources/MSFT_xADUser/MSFT_xADUser.psm1
@@ -1057,7 +1057,11 @@ function Test-TargetResource
                     $isCompliant = $false
                 }
             }
-            # Only check properties that are returned by Get-TargetResource
+            elseif ($parameter -eq 'ChangePasswordAtLogon' -and $PSBoundParameters.$parameter -eq $true -and $targetResource.Ensure -eq 'Present')
+            {
+                # Only process the ChangePasswordAtLogon = $true parameter during new user creation
+            }
+        # Only check properties that are returned by Get-TargetResource
             elseif ($targetResource.ContainsKey($parameter))
             {
                 # This check is required to be able to explicitly remove values with an empty string, if required
@@ -1447,6 +1451,7 @@ function Set-TargetResource
     # Add common name, ensure and enabled as they may not be explicitly passed
     $PSBoundParameters['Ensure'] = $Ensure
     $PSBoundParameters['Enabled'] = $Enabled
+    $newADUser = $false
 
     if ($Ensure -eq 'Present')
     {
@@ -1482,6 +1487,8 @@ function Set-TargetResource
 
                 # Now retrieve the newly created user
                 $targetResource = Get-TargetResource @PSBoundParameters
+
+                $newADUser = $true
             }
         }
 
@@ -1541,6 +1548,10 @@ function Set-TargetResource
 
                         Set-ADAccountPassword @adCommonParameters -Reset -NewPassword $Password.Password
                     }
+                }
+                elseif ($parameter -eq 'ChangePasswordAtLogon' -and $PSBoundParameters.$parameter -eq $true -and $newADUser -eq $false)
+                {
+                    # Only process the ChangePasswordAtLogon = $true parameter during new user creation
                 }
                 elseif ($parameter -eq 'Enabled' -and ($PSBoundParameters.$parameter -ne $targetResource.$parameter))
                 {

--- a/DSCResources/MSFT_xADUser/MSFT_xADUser.psm1
+++ b/DSCResources/MSFT_xADUser/MSFT_xADUser.psm1
@@ -1060,6 +1060,7 @@ function Test-TargetResource
             elseif ($parameter -eq 'ChangePasswordAtLogon' -and $PSBoundParameters.$parameter -eq $true -and $targetResource.Ensure -eq 'Present')
             {
                 # Only process the ChangePasswordAtLogon = $true parameter during new user creation
+                continue
             }
         # Only check properties that are returned by Get-TargetResource
             elseif ($targetResource.ContainsKey($parameter))
@@ -1543,6 +1544,8 @@ function Set-TargetResource
                 elseif ($parameter -eq 'ChangePasswordAtLogon' -and $PSBoundParameters.$parameter -eq $true -and $newADUser -eq $false)
                 {
                     # Only process the ChangePasswordAtLogon = $true parameter during new user creation
+                    Write-Verbose "Here"
+                    continue
                 }
                 elseif ($parameter -eq 'Enabled' -and ($PSBoundParameters.$parameter -ne $targetResource.$parameter))
                 {

--- a/DSCResources/MSFT_xADUser/MSFT_xADUser.schema.mof
+++ b/DSCResources/MSFT_xADUser/MSFT_xADUser.schema.mof
@@ -45,7 +45,7 @@ class MSFT_xADUser : OMI_BaseResource
     [Write, Description("Specifies a name in addition to a user's given name and surname, such as the user's middle name. This parameter sets the OtherName property of a user object. The LDAP display name (ldapDisplayName) of this property is middleName.")] String OtherName;
     [Write, Description("Specifies if the account is enabled (default True)")] Boolean Enabled;
     [Write, Description("Specifies whether the account password can be changed")] Boolean CannotChangePassword;
-    [Write, Description("Specifies whether the account password must be changed during the next logon attempt. This cannot be set to true if the PasswordNeverExpires property is also set to true")] Boolean ChangePasswordAtLogon;
+    [Write, Description("Specifies whether the account password must be changed during the next logon attempt. This will only be set to 'true' once when the user is initially created. This cannot be set to true if the PasswordNeverExpires property is also set to true")] Boolean ChangePasswordAtLogon;
     [Write, Description("Specifies whether the password of an account can expire")] Boolean PasswordNeverExpires;
     [Write, Description("Specifies the Active Directory Domain Services instance to use to perform the task.")] String DomainController;
     [Write, Description("Specifies the user account credentials to use to perform this task"), EmbeddedInstance("MSFT_Credential")] String DomainAdministratorCredential;

--- a/Tests/Unit/MSFT_xADUser.Tests.ps1
+++ b/Tests/Unit/MSFT_xADUser.Tests.ps1
@@ -67,7 +67,7 @@ try
             'Manager', 'LogonWorkstations', 'Organization', 'OtherName'
         )
         $testBooleanProperties = @(
-            'PasswordNeverExpires', 'CannotChangePassword', 'ChangePasswordAtLogon', 'TrustedForDelegation', 'Enabled','AccountNotDelegated',
+            'PasswordNeverExpires', 'CannotChangePassword', 'TrustedForDelegation', 'Enabled','AccountNotDelegated',
             'AllowReversiblePasswordEncryption', 'CompoundIdentitySupported', 'PasswordNotRequired', 'SmartcardLogonRequired'
         )
         $testArrayProperties = @('ServicePrincipalNames', 'ProxyAddresses')
@@ -355,6 +355,80 @@ try
                 }
 
             } #end foreach test boolean property
+
+            It "Should pass when ChangePasswordAtLogon is false and matches the AD Account property" {
+                $testParameter = 'ChangePasswordAtLogon'
+                $testParameterValue = $false
+                $testValidPresentParams = $testPresentParams.Clone()
+                $testValidPresentParams[$testParameter] = $testParameterValue
+                $validADUser = $testPresentParams.Clone()
+                Mock -CommandName Get-TargetResource -MockWith {
+                    $validADUser[$testParameter] = $testParameterValue
+                    return $validADUser
+                }
+
+                Test-TargetResource @testValidPresentParams | Should -Be $true
+            }
+
+            It "Should fail when ChangePasswordAtLogon is false and does not match the AD Account property" {
+                $testParameter = 'ChangePasswordAtLogon'
+                $testParameterValue = $false
+                $testValidPresentParams = $testPresentParams.Clone()
+                $testValidPresentParams[$testParameter] = $testParameterValue
+                $invalidADUser = $testPresentParams.Clone()
+                Mock -CommandName Get-TargetResource -MockWith {
+                    $invalidADUser[$testParameter] = -not $testParameterValue
+                    return $invalidADUser
+                }
+
+                Test-TargetResource @testValidPresentParams | Should -Be $false
+            }
+
+            It "Should pass when ChangePasswordAtLogon is true and matches the AD Account property and the user already exists" {
+                $testParameter = 'ChangePasswordAtLogon'
+                $testParameterValue = $true
+                $testValidPresentParams = $testPresentParams.Clone()
+                $testValidPresentParams[$testParameter] = $testParameterValue
+                $validADUser = $testPresentParams.Clone()
+                $validADUser['Ensure'] = 'Present'
+                Mock -CommandName Get-TargetResource -MockWith {
+                    $validADUser[$testParameter] = $testParameterValue
+                    return $validADUser
+                }
+
+                Test-TargetResource @testValidPresentParams | Should -Be $true
+            }
+
+            It "Should pass when ChangePasswordAtLogon is true and does not match the AD Account property and the user already exists" {
+                $testParameter = 'ChangePasswordAtLogon'
+                $testParameterValue = $true
+                $testValidPresentParams = $testPresentParams.Clone()
+                $testValidPresentParams[$testParameter] = $testParameterValue
+                $invalidADUser = $testPresentParams.Clone()
+                $invalidADUser['Ensure'] = 'Present'
+                Mock -CommandName Get-TargetResource -MockWith {
+                    $invalidADUser[$testParameter] = -not $testParameterValue
+                    return $invalidADUser
+                }
+
+                Test-TargetResource @testValidPresentParams | Should -Be $true
+            }
+
+            It "Should fail when ChangePasswordAtLogon is true and does not match the AD Account property and the user does not exist" {
+                $testParameter = 'ChangePasswordAtLogon'
+                $testParameterValue = $true
+                $testValidPresentParams = $testPresentParams.Clone()
+                $testValidPresentParams[$testParameter] = $testParameterValue
+                $invalidADUser = $testPresentParams.Clone()
+                $invalidADUser['Ensure'] = 'Absent'
+                Mock -CommandName Get-TargetResource -MockWith {
+                    $invalidADUser[$testParameter] = -not $testParameterValue
+                    return $invalidADUser
+                }
+
+                Test-TargetResource @testValidPresentParams | Should -Be $false
+            }
+
             foreach ($testParameter in $testArrayProperties)
             {
                 It "Passes when user account '$testParameter' matches empty AD account property" {

--- a/Tests/Unit/MSFT_xADUser.Tests.ps1
+++ b/Tests/Unit/MSFT_xADUser.Tests.ps1
@@ -762,6 +762,23 @@ try
                 Assert-MockCalled -CommandName Set-ADUser -ParameterFilter { $mockBoolParam } -Scope It -Exactly 1
             }
 
+            It "Should call 'Set-ADUser' with the correct parameter when 'ChangePasswordAtLogon' is true and the user does exist" {
+                $mockBoolParam = 'ChangePasswordAtLogon'
+                $newPresentParams = $testPresentParams.Clone()
+                $newAbsentParams = $testAbsentParams.Clone()
+
+                BeforeAll {
+                    Mock -CommandName Get-TargetResource -ParameterFilter { $Username -eq $newPresentParams.UserName } `
+                        -MockWith { $newPresentParams }
+                    Mock -CommandName Set-ADUser -ParameterFilter { $mockBoolParam }
+                }
+
+                Set-TargetResource @newPresentParams -Verbose
+
+                Assert-MockCalled -CommandName Set-ADUser -ParameterFilter { $mockBoolParam -eq $true } `
+                    -Scope It -Exactly 0
+            }
+
             Context 'When RestoreFromRecycleBin is used' {
                 BeforeAll {
                     Mock -CommandName Get-TargetResource -MockWith {

--- a/Tests/Unit/MSFT_xADUser.Tests.ps1
+++ b/Tests/Unit/MSFT_xADUser.Tests.ps1
@@ -779,6 +779,32 @@ try
                     -Scope It -Exactly 0
             }
 
+            It "Should call 'Set-ADUser' with the correct parameter when 'ChangePasswordAtLogon' is true and the user does not exist" {
+                $mockBoolParam = 'ChangePasswordAtLogon'
+                $preNewUserParams = $testAbsentParams.Clone()
+                $postNewUserParams = $testPresentParams.Clone()
+
+                BeforeAll {
+                    Mock -CommandName Get-TargetResource -ParameterFilter { $Username -eq $newPresentParams.UserName } `
+                        -MockWith {
+                            if ($script:newADUser)
+                            {
+                                $preNewUserParams
+                            }
+                            else
+                            {
+                                $postNewUserParams
+                            }
+                        }
+                    Mock -CommandName Set-ADUser -ParameterFilter { $mockBoolParam }
+                }
+
+                Set-TargetResource @newPresentParams -Verbose
+
+                Assert-MockCalled -CommandName Set-ADUser -ParameterFilter { $mockBoolParam -eq $true } `
+                    -Scope It -Exactly 1
+            }
+
             Context 'When RestoreFromRecycleBin is used' {
                 BeforeAll {
                     Mock -CommandName Get-TargetResource -MockWith {


### PR DESCRIPTION
#### Pull Request (PR) description

This PR changes the behaviour of the `ChangePasswordAtLogon` property of the `xADUser` resource so that if it is present and set to `true` in the resource, it is only set once at user creation. The current behaviour keeps resetting the property to `true` at every DSC refresh if the user has subsequently changed their password which is not useful.
 
Also fixed the issue links in the changelog.

#### This Pull Request (PR) fixes the following issues

- Fixes #414

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry under the Unreleased section in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in resource directory README.md.
- [x] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xactivedirectory/417)
<!-- Reviewable:end -->
